### PR TITLE
feat(search): implement advanced search and filtering

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -18,6 +18,7 @@ import { RecurringSplitsModule } from './recurring-splits/recurring-splits.modul
 import { ReceiptsModule } from './receipts/receipts.module';
 import { SplitHistoryModule } from './split-history/split-history.module';
 import { ActivitiesModule } from './modules/activities/activities.module';
+import { SearchModule } from './search/search.module';
 
 // Load environment variables
 dotenv.config({
@@ -68,6 +69,7 @@ dotenv.config({
     ReceiptsModule,
     SplitHistoryModule,
     ActivitiesModule,
+    SearchModule,
   ],
 })
 export class AppModule { }

--- a/backend/src/migrations/1738127000000-AddSearchIndexes.ts
+++ b/backend/src/migrations/1738127000000-AddSearchIndexes.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Migration to add search indexes for full-text search and fuzzy matching
+ * 
+ * I'm using PostgreSQL's pg_trgm extension for fuzzy matching and
+ * GIN indexes for efficient full-text search. These indexes are
+ * essential for good search performance at scale.
+ */
+export class AddSearchIndexes1738127000000 implements MigrationInterface {
+  name = 'AddSearchIndexes1738127000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Enable the pg_trgm extension for fuzzy matching
+    // This is safe to run even if already enabled
+    await queryRunner.query(`
+      CREATE EXTENSION IF NOT EXISTS pg_trgm;
+    `);
+
+    // GIN index for full-text search on splits.description
+    // Using 'english' configuration for stemming and stop words
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_splits_description_fts 
+      ON splits USING GIN (to_tsvector('english', COALESCE(description, '')));
+    `);
+
+    // Trigram index for fuzzy matching on splits.description
+    // This enables similarity() queries with good performance
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_splits_description_trgm 
+      ON splits USING GIN (COALESCE(description, '') gin_trgm_ops);
+    `);
+
+    // GIN index for full-text search on items.name
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_items_name_fts 
+      ON items USING GIN (to_tsvector('english', name));
+    `);
+
+    // Trigram index for fuzzy matching on items.name
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_items_name_trgm 
+      ON items USING GIN (name gin_trgm_ops);
+    `);
+
+    // Composite index for common filter + sort patterns
+    // This speeds up queries filtered by status and sorted by date
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_splits_status_created 
+      ON splits (status, "createdAt" DESC);
+    `);
+
+    // B-tree index for amount range queries
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_splits_amount_range 
+      ON splits ("totalAmount");
+    `);
+
+    // Index for participant-based filtering
+    // Speeds up EXISTS subqueries when filtering by participants
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_participants_split_user 
+      ON participants ("splitId", "userId");
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove all the indexes we created
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_participants_split_user;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_splits_amount_range;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_splits_status_created;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_items_name_trgm;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_items_name_fts;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_splits_description_trgm;`);
+    await queryRunner.query(`DROP INDEX IF EXISTS idx_splits_description_fts;`);
+    
+    // Note: We don't drop pg_trgm extension as other features might use it
+  }
+}

--- a/backend/src/search/dto/index.ts
+++ b/backend/src/search/dto/index.ts
@@ -1,0 +1,2 @@
+export * from './search-splits.dto';
+export * from './search-result.dto';

--- a/backend/src/search/dto/search-result.dto.ts
+++ b/backend/src/search/dto/search-result.dto.ts
@@ -1,0 +1,69 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Split } from '../../entities/split.entity';
+
+/**
+ * Highlighted matches for search result display
+ * These contain the matched text with <mark> tags for frontend highlighting
+ */
+export class SearchHighlightsDto {
+  @ApiPropertyOptional({ 
+    description: 'Highlighted description snippet with matched terms wrapped in <mark> tags'
+  })
+  description?: string;
+
+  @ApiPropertyOptional({ 
+    description: 'Array of highlighted item names that matched the query',
+    type: [String]
+  })
+  itemNames?: string[];
+}
+
+/**
+ * Single search result item with relevance info
+ * I'm including the score so the frontend could optionally show relevance
+ */
+export class SearchResultItemDto {
+  @ApiProperty({ description: 'The matched split entity' })
+  split!: Split;
+
+  @ApiProperty({ 
+    description: 'Highlighted text snippets showing where matches occurred',
+    type: SearchHighlightsDto
+  })
+  highlights!: SearchHighlightsDto;
+
+  @ApiProperty({ 
+    description: 'Relevance score (higher = more relevant)',
+    example: 0.85
+  })
+  score!: number;
+}
+
+/**
+ * Paginated search response
+ * Using cursor-based pagination for stable results during scrolling
+ */
+export class SearchResultDto {
+  @ApiProperty({ 
+    description: 'Array of search results',
+    type: [SearchResultItemDto]
+  })
+  data!: SearchResultItemDto[];
+
+  @ApiProperty({ 
+    description: 'Total number of matching results',
+    example: 42
+  })
+  total!: number;
+
+  @ApiPropertyOptional({ 
+    description: 'Cursor for fetching the next page (null if no more results)'
+  })
+  cursor?: string | null;
+
+  @ApiProperty({ 
+    description: 'Whether more results are available',
+    example: true
+  })
+  hasMore!: boolean;
+}

--- a/backend/src/search/dto/search-splits.dto.ts
+++ b/backend/src/search/dto/search-splits.dto.ts
@@ -1,0 +1,102 @@
+import { IsString, IsOptional, IsNumber, IsArray, IsDateString, ValidateNested, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Filter options for split search
+ * Allows narrowing results by date, amount, status and participants
+ */
+export class SearchFiltersDto {
+  @ApiPropertyOptional({ description: 'Filter splits created on or after this date' })
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @ApiPropertyOptional({ description: 'Filter splits created on or before this date' })
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @ApiPropertyOptional({ description: 'Minimum total amount filter' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  minAmount?: number;
+
+  @ApiPropertyOptional({ description: 'Maximum total amount filter' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Type(() => Number)
+  maxAmount?: number;
+
+  @ApiPropertyOptional({ 
+    description: 'Filter by split status',
+    type: [String],
+    example: ['active', 'completed']
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  status?: string[];
+
+  @ApiPropertyOptional({ 
+    description: 'Filter by participant user IDs',
+    type: [String]
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  participants?: string[];
+}
+
+/**
+ * Main search request DTO
+ * I'm keeping this flexible to handle various search scenarios
+ */
+export class SearchSplitsDto {
+  @ApiProperty({ 
+    description: 'Search query for full-text search across split descriptions and item names',
+    example: 'dinner restaurant'
+  })
+  @IsString()
+  query!: string;
+
+  @ApiPropertyOptional({ 
+    description: 'Advanced filter options',
+    type: SearchFiltersDto
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => SearchFiltersDto)
+  filters?: SearchFiltersDto;
+
+  @ApiPropertyOptional({ 
+    description: 'Sort option: createdAt_desc, createdAt_asc, amount_desc, amount_asc',
+    default: 'createdAt_desc'
+  })
+  @IsOptional()
+  @IsString()
+  sort?: string;
+
+  @ApiPropertyOptional({ 
+    description: 'Number of results to return',
+    default: 20,
+    minimum: 1,
+    maximum: 100
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit?: number;
+
+  @ApiPropertyOptional({ 
+    description: 'Cursor for pagination (base64 encoded)',
+  })
+  @IsOptional()
+  @IsString()
+  cursor?: string;
+}

--- a/backend/src/search/index.ts
+++ b/backend/src/search/index.ts
@@ -1,0 +1,4 @@
+export * from './search.module';
+export * from './search.service';
+export * from './search.controller';
+export * from './dto';

--- a/backend/src/search/search.controller.spec.ts
+++ b/backend/src/search/search.controller.spec.ts
@@ -1,0 +1,118 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+import { SearchResultDto } from './dto/search-result.dto';
+
+/**
+ * Unit tests for SearchController
+ * Testing endpoint behavior with mocked service
+ */
+describe('SearchController', () => {
+  let controller: SearchController;
+  let searchService: jest.Mocked<SearchService>;
+
+  const mockSearchResult: SearchResultDto = {
+    data: [
+      {
+        split: {
+          id: 'split-1',
+          totalAmount: 100,
+          amountPaid: 50,
+          status: 'active',
+          description: 'Test split',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          participants: [],
+        },
+        highlights: {
+          description: 'Test <mark>split</mark>',
+        },
+        score: 0.8,
+      },
+    ],
+    total: 1,
+    cursor: null,
+    hasMore: false,
+  };
+
+  beforeEach(async () => {
+    const mockSearchService = {
+      searchSplits: jest.fn().mockResolvedValue(mockSearchResult),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SearchController],
+      providers: [
+        {
+          provide: SearchService,
+          useValue: mockSearchService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<SearchController>(SearchController);
+    searchService = module.get(SearchService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('searchSplits', () => {
+    it('should call searchService.searchSplits with correct parameters', async () => {
+      const searchDto = {
+        query: 'dinner',
+        filters: {
+          status: ['active'],
+        },
+        limit: 20,
+      };
+
+      await controller.searchSplits(searchDto);
+
+      expect(searchService.searchSplits).toHaveBeenCalledWith(searchDto);
+    });
+
+    it('should return search results from service', async () => {
+      const result = await controller.searchSplits({ query: 'dinner' });
+
+      expect(result).toEqual(mockSearchResult);
+    });
+
+    it('should handle empty query', async () => {
+      const result = await controller.searchSplits({ query: '' });
+
+      expect(searchService.searchSplits).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
+    it('should pass all filter options correctly', async () => {
+      const searchDto = {
+        query: 'meeting',
+        filters: {
+          dateFrom: '2024-01-01',
+          dateTo: '2024-12-31',
+          minAmount: 10,
+          maxAmount: 1000,
+          status: ['active', 'completed'],
+          participants: ['user-1', 'user-2'],
+        },
+        sort: 'createdAt_desc',
+        limit: 50,
+        cursor: 'abc123',
+      };
+
+      await controller.searchSplits(searchDto);
+
+      expect(searchService.searchSplits).toHaveBeenCalledWith(searchDto);
+    });
+
+    it('should handle service errors gracefully', async () => {
+      searchService.searchSplits.mockRejectedValueOnce(new Error('Database error'));
+
+      await expect(controller.searchSplits({ query: 'test' }))
+        .rejects
+        .toThrow('Database error');
+    });
+  });
+});

--- a/backend/src/search/search.controller.ts
+++ b/backend/src/search/search.controller.ts
@@ -1,0 +1,70 @@
+import { 
+  Controller, 
+  Post, 
+  Body, 
+  HttpCode, 
+  HttpStatus,
+  ValidationPipe,
+} from '@nestjs/common';
+import { 
+  ApiTags, 
+  ApiOperation, 
+  ApiResponse, 
+  ApiBody,
+} from '@nestjs/swagger';
+import { SearchService } from './search.service';
+import { SearchSplitsDto } from './dto/search-splits.dto';
+import { SearchResultDto } from './dto/search-result.dto';
+
+/**
+ * Controller for search endpoints
+ * I'm keeping this focused on splits for now, but the structure
+ * allows easy extension to search participants/transactions separately
+ */
+@ApiTags('Search')
+@Controller('search')
+export class SearchController {
+  constructor(private readonly searchService: SearchService) {}
+
+  @Post('splits')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ 
+    summary: 'Search splits with full-text search and filters',
+    description: `
+      Performs full-text search across split descriptions and item names.
+      Supports fuzzy matching for typo tolerance.
+      
+      **Filters:**
+      - Date range (dateFrom, dateTo)
+      - Amount range (minAmount, maxAmount)
+      - Status (active, completed, partial)
+      - Participants (user IDs)
+      
+      **Sorting:**
+      - createdAt_desc (default)
+      - createdAt_asc
+      - amount_desc
+      - amount_asc
+      
+      **Pagination:**
+      Uses cursor-based pagination for stable results.
+      Pass the cursor from the previous response to get the next page.
+    `
+  })
+  @ApiBody({ type: SearchSplitsDto })
+  @ApiResponse({ 
+    status: 200, 
+    description: 'Search results with highlighted matches',
+    type: SearchResultDto,
+  })
+  @ApiResponse({ 
+    status: 400, 
+    description: 'Invalid search parameters',
+  })
+  async searchSplits(
+    @Body(new ValidationPipe({ transform: true, whitelist: true })) 
+    searchDto: SearchSplitsDto,
+  ): Promise<SearchResultDto> {
+    return this.searchService.searchSplits(searchDto);
+  }
+}

--- a/backend/src/search/search.module.ts
+++ b/backend/src/search/search.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SearchController } from './search.controller';
+import { SearchService } from './search.service';
+import { Split } from '../entities/split.entity';
+import { Item } from '../entities/item.entity';
+import { Participant } from '../entities/participant.entity';
+
+/**
+ * Search module providing full-text search capabilities
+ * 
+ * I'm injecting the repositories we need for searching:
+ * - Split: main entity being searched
+ * - Item: for searching item names within splits
+ * - Participant: for filtering by participants
+ */
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Split, Item, Participant]),
+  ],
+  controllers: [SearchController],
+  providers: [SearchService],
+  exports: [SearchService],
+})
+export class SearchModule {}

--- a/backend/src/search/search.service.spec.ts
+++ b/backend/src/search/search.service.spec.ts
@@ -1,0 +1,281 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { SearchService } from './search.service';
+import { Split } from '../entities/split.entity';
+import { Item } from '../entities/item.entity';
+import { Participant } from '../entities/participant.entity';
+
+/**
+ * Unit tests for SearchService
+ * Testing the core search functionality with mocked repositories
+ */
+describe('SearchService', () => {
+  let service: SearchService;
+  let splitRepository: jest.Mocked<Repository<Split>>;
+  let itemRepository: jest.Mocked<Repository<Item>>;
+  let participantRepository: jest.Mocked<Repository<Participant>>;
+
+  // Mock split data for testing
+  const mockSplits: Split[] = [
+    {
+      id: 'split-1',
+      totalAmount: 100,
+      amountPaid: 50,
+      status: 'active',
+      description: 'Dinner at fancy restaurant',
+      createdAt: new Date('2024-01-15'),
+      updatedAt: new Date('2024-01-15'),
+      items: [
+        {
+          id: 'item-1',
+          splitId: 'split-1',
+          name: 'Pizza',
+          quantity: 2,
+          unitPrice: 20,
+          totalPrice: 40,
+          assignedToIds: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        } as Item,
+      ],
+      participants: [],
+    } as Split,
+    {
+      id: 'split-2',
+      totalAmount: 200,
+      amountPaid: 200,
+      status: 'completed',
+      description: 'Lunch meeting with team',
+      createdAt: new Date('2024-01-10'),
+      updatedAt: new Date('2024-01-10'),
+      items: [],
+      participants: [],
+    } as Split,
+  ];
+
+  // Mock query builder that simulates TypeORM behavior
+  const createMockQueryBuilder = (results: Split[]): Partial<SelectQueryBuilder<Split>> => {
+    const qb: Partial<SelectQueryBuilder<Split>> = {
+      leftJoinAndSelect: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      take: jest.fn().mockReturnThis(),
+      getMany: jest.fn().mockResolvedValue(results),
+      getCount: jest.fn().mockResolvedValue(results.length),
+    };
+    return qb;
+  };
+
+  beforeEach(async () => {
+    const mockQueryBuilder = createMockQueryBuilder(mockSplits);
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        SearchService,
+        {
+          provide: getRepositoryToken(Split),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          },
+        },
+        {
+          provide: getRepositoryToken(Item),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          },
+        },
+        {
+          provide: getRepositoryToken(Participant),
+          useValue: {
+            createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
+          },
+        },
+      ],
+    }).compile();
+
+    service = module.get<SearchService>(SearchService);
+    splitRepository = module.get(getRepositoryToken(Split));
+    itemRepository = module.get(getRepositoryToken(Item));
+    participantRepository = module.get(getRepositoryToken(Participant));
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('searchSplits', () => {
+    it('should return search results for a valid query', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.data).toBeInstanceOf(Array);
+      expect(result.total).toBe(mockSplits.length);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it('should apply date filters correctly', async () => {
+      const result = await service.searchSplits({
+        query: 'lunch',
+        filters: {
+          dateFrom: '2024-01-01',
+          dateTo: '2024-01-31',
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(splitRepository.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should apply amount filters correctly', async () => {
+      const result = await service.searchSplits({
+        query: 'meeting',
+        filters: {
+          minAmount: 50,
+          maxAmount: 500,
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(splitRepository.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should apply status filters correctly', async () => {
+      const result = await service.searchSplits({
+        query: 'team',
+        filters: {
+          status: ['active', 'completed'],
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(splitRepository.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should apply participant filters correctly', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+        filters: {
+          participants: ['user-1', 'user-2'],
+        },
+      });
+
+      expect(result).toBeDefined();
+      expect(splitRepository.createQueryBuilder).toHaveBeenCalled();
+    });
+
+    it('should handle empty query gracefully', async () => {
+      const result = await service.searchSplits({
+        query: '',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.data).toBeInstanceOf(Array);
+    });
+
+    it('should respect limit parameter', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+        limit: 10,
+      });
+
+      expect(result).toBeDefined();
+    });
+
+    it('should enforce maximum limit', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+        limit: 1000, // Exceeds max
+      });
+
+      expect(result).toBeDefined();
+      // Service should internally cap at 100
+    });
+
+    it('should handle cursor pagination', async () => {
+      // First get results without cursor
+      const firstPage = await service.searchSplits({
+        query: 'dinner',
+        limit: 1,
+      });
+
+      expect(firstPage).toBeDefined();
+      // In real scenario, we'd use the cursor for next page
+    });
+
+    it('should support different sort options', async () => {
+      const sortOptions = [
+        'createdAt_desc',
+        'createdAt_asc',
+        'amount_desc',
+        'amount_asc',
+      ];
+
+      for (const sort of sortOptions) {
+        const result = await service.searchSplits({
+          query: 'dinner',
+          sort,
+        });
+
+        expect(result).toBeDefined();
+      }
+    });
+
+    it('should generate highlights for matching content', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+      });
+
+      expect(result).toBeDefined();
+      // In real scenario with matching data, highlights would contain marked text
+      expect(result.data[0]).toHaveProperty('highlights');
+    });
+
+    it('should calculate relevance scores', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner restaurant',
+      });
+
+      expect(result).toBeDefined();
+      expect(result.data[0]).toHaveProperty('score');
+      expect(typeof result.data[0].score).toBe('number');
+    });
+
+    it('should sanitize potentially malicious queries', async () => {
+      const result = await service.searchSplits({
+        query: '<script>alert("xss")</script>',
+      });
+
+      expect(result).toBeDefined();
+      // Query should be sanitized, not throw
+    });
+
+    it('should handle very long queries', async () => {
+      const longQuery = 'a'.repeat(500);
+      const result = await service.searchSplits({
+        query: longQuery,
+      });
+
+      expect(result).toBeDefined();
+      // Query should be truncated internally
+    });
+  });
+
+  describe('cursor encoding/decoding', () => {
+    it('should produce valid cursor strings', async () => {
+      const result = await service.searchSplits({
+        query: 'dinner',
+        limit: 1,
+      });
+
+      if (result.cursor) {
+        // Cursor should be base64 encoded
+        expect(() => Buffer.from(result.cursor!, 'base64')).not.toThrow();
+      }
+    });
+  });
+});

--- a/backend/src/search/search.service.ts
+++ b/backend/src/search/search.service.ts
@@ -1,0 +1,456 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
+import { Split } from '../entities/split.entity';
+import { Item } from '../entities/item.entity';
+import { Participant } from '../entities/participant.entity';
+import { 
+  SearchSplitsDto, 
+  SearchFiltersDto 
+} from './dto/search-splits.dto';
+import { 
+  SearchResultDto, 
+  SearchResultItemDto, 
+  SearchHighlightsDto 
+} from './dto/search-result.dto';
+
+/**
+ * Decoded cursor structure for pagination
+ * I'm using createdAt + id to ensure stable pagination even with new inserts
+ */
+interface DecodedCursor {
+  createdAt: string;
+  id: string;
+}
+
+/**
+ * Search service implementing PostgreSQL full-text search
+ * 
+ * I chose PostgreSQL's built-in FTS over external solutions like Elasticsearch
+ * because it integrates seamlessly with our existing TypeORM setup and 
+ * provides sufficient performance for this application's scale.
+ */
+@Injectable()
+export class SearchService {
+  private readonly logger = new Logger(SearchService.name);
+  
+  // Default pagination settings
+  private readonly DEFAULT_LIMIT = 20;
+  private readonly MAX_LIMIT = 100;
+  
+  // Minimum similarity threshold for fuzzy matching (0-1 scale)
+  private readonly FUZZY_THRESHOLD = 0.3;
+
+  constructor(
+    @InjectRepository(Split)
+    private readonly splitRepository: Repository<Split>,
+    @InjectRepository(Item)
+    private readonly itemRepository: Repository<Item>,
+    @InjectRepository(Participant)
+    private readonly participantRepository: Repository<Participant>,
+  ) {}
+
+  /**
+   * Main search entry point
+   * Combines full-text search with fuzzy matching and advanced filters
+   */
+  async searchSplits(dto: SearchSplitsDto): Promise<SearchResultDto> {
+    const limit = Math.min(dto.limit || this.DEFAULT_LIMIT, this.MAX_LIMIT);
+    const searchQuery = this.sanitizeSearchQuery(dto.query);
+    
+    // I'm building the query in steps for clarity and maintainability
+    let queryBuilder = this.splitRepository
+      .createQueryBuilder('split')
+      .leftJoinAndSelect('split.items', 'item')
+      .leftJoinAndSelect('split.participants', 'participant');
+
+    // Apply full-text search if query is provided
+    if (searchQuery.trim()) {
+      queryBuilder = this.applyFullTextSearch(queryBuilder, searchQuery);
+    }
+
+    // Apply advanced filters
+    if (dto.filters) {
+      queryBuilder = this.applyFilters(queryBuilder, dto.filters);
+    }
+
+    // Apply cursor-based pagination
+    const cursor = dto.cursor ? this.decodeCursor(dto.cursor) : null;
+    if (cursor) {
+      queryBuilder = this.applyCursor(queryBuilder, cursor, dto.sort);
+    }
+
+    // Apply sorting
+    queryBuilder = this.applySorting(queryBuilder, dto.sort);
+
+    // Get total count before pagination (for UI purposes)
+    const total = await this.getFilteredCount(dto);
+
+    // Fetch results with one extra to check if there are more
+    const results = await queryBuilder
+      .take(limit + 1)
+      .getMany();
+
+    // Check if there are more results beyond this page
+    const hasMore = results.length > limit;
+    const pageResults = hasMore ? results.slice(0, limit) : results;
+
+    // Build response with highlights
+    const data = await this.buildSearchResults(pageResults, searchQuery);
+
+    // Generate next cursor if there are more results
+    const nextCursor = hasMore && pageResults.length > 0
+      ? this.encodeCursor(pageResults[pageResults.length - 1])
+      : null;
+
+    return {
+      data,
+      total,
+      cursor: nextCursor,
+      hasMore,
+    };
+  }
+
+  /**
+   * Apply PostgreSQL full-text search using to_tsvector and to_tsquery
+   * I'm also adding trigram similarity for fuzzy matching on typos
+   */
+  private applyFullTextSearch(
+    queryBuilder: SelectQueryBuilder<Split>,
+    searchQuery: string,
+  ): SelectQueryBuilder<Split> {
+    // Convert search query to tsquery format
+    // Using plainto_tsquery for simple queries, websearch_to_tsquery for complex ones
+    const tsQuery = this.buildTsQuery(searchQuery);
+
+    // Full-text search on split description
+    queryBuilder.andWhere(`(
+      to_tsvector('english', COALESCE(split.description, '')) @@ to_tsquery('english', :tsQuery)
+      OR similarity(COALESCE(split.description, ''), :rawQuery) > :threshold
+      OR EXISTS (
+        SELECT 1 FROM items i 
+        WHERE i."splitId" = split.id 
+        AND (
+          to_tsvector('english', i.name) @@ to_tsquery('english', :tsQuery)
+          OR similarity(i.name, :rawQuery) > :threshold
+        )
+      )
+    )`, { 
+      tsQuery, 
+      rawQuery: searchQuery,
+      threshold: this.FUZZY_THRESHOLD 
+    });
+
+    // Add relevance score for sorting
+    queryBuilder.addSelect(`(
+      COALESCE(ts_rank(to_tsvector('english', COALESCE(split.description, '')), to_tsquery('english', :tsQuery)), 0) +
+      COALESCE(similarity(COALESCE(split.description, ''), :rawQuery), 0)
+    )`, 'search_score');
+
+    return queryBuilder;
+  }
+
+  /**
+   * Apply advanced filters to the query
+   */
+  private applyFilters(
+    queryBuilder: SelectQueryBuilder<Split>,
+    filters: SearchFiltersDto,
+  ): SelectQueryBuilder<Split> {
+    // Date range filters
+    if (filters.dateFrom) {
+      queryBuilder.andWhere('split.createdAt >= :dateFrom', { 
+        dateFrom: new Date(filters.dateFrom) 
+      });
+    }
+    if (filters.dateTo) {
+      queryBuilder.andWhere('split.createdAt <= :dateTo', { 
+        dateTo: new Date(filters.dateTo) 
+      });
+    }
+
+    // Amount range filters
+    if (filters.minAmount !== undefined) {
+      queryBuilder.andWhere('split.totalAmount >= :minAmount', { 
+        minAmount: filters.minAmount 
+      });
+    }
+    if (filters.maxAmount !== undefined) {
+      queryBuilder.andWhere('split.totalAmount <= :maxAmount', { 
+        maxAmount: filters.maxAmount 
+      });
+    }
+
+    // Status filter - I'm using IN for multiple statuses
+    if (filters.status && filters.status.length > 0) {
+      queryBuilder.andWhere('split.status IN (:...statuses)', { 
+        statuses: filters.status 
+      });
+    }
+
+    // Participant filter - find splits where any of the specified users are participants
+    if (filters.participants && filters.participants.length > 0) {
+      queryBuilder.andWhere(`EXISTS (
+        SELECT 1 FROM participants p 
+        WHERE p."splitId" = split.id 
+        AND p."userId" IN (:...participantIds)
+      )`, { 
+        participantIds: filters.participants 
+      });
+    }
+
+    return queryBuilder;
+  }
+
+  /**
+   * Apply cursor-based pagination
+   * Using composite cursor (createdAt, id) for stable ordering
+   */
+  private applyCursor(
+    queryBuilder: SelectQueryBuilder<Split>,
+    cursor: DecodedCursor,
+    sort?: string,
+  ): SelectQueryBuilder<Split> {
+    // Determine sort direction from the sort parameter
+    const isAscending = sort?.endsWith('_asc') ?? false;
+    const operator = isAscending ? '>' : '<';
+
+    // Compound cursor condition for tie-breaking
+    queryBuilder.andWhere(`(
+      split."createdAt" ${operator} :cursorCreatedAt
+      OR (split."createdAt" = :cursorCreatedAt AND split.id ${operator} :cursorId)
+    )`, {
+      cursorCreatedAt: new Date(cursor.createdAt),
+      cursorId: cursor.id,
+    });
+
+    return queryBuilder;
+  }
+
+  /**
+   * Apply sorting based on sort parameter
+   */
+  private applySorting(
+    queryBuilder: SelectQueryBuilder<Split>,
+    sort?: string,
+  ): SelectQueryBuilder<Split> {
+    switch (sort) {
+      case 'createdAt_asc':
+        queryBuilder.orderBy('split.createdAt', 'ASC').addOrderBy('split.id', 'ASC');
+        break;
+      case 'amount_desc':
+        queryBuilder.orderBy('split.totalAmount', 'DESC').addOrderBy('split.id', 'DESC');
+        break;
+      case 'amount_asc':
+        queryBuilder.orderBy('split.totalAmount', 'ASC').addOrderBy('split.id', 'ASC');
+        break;
+      case 'createdAt_desc':
+      default:
+        // Default: newest first
+        queryBuilder.orderBy('split.createdAt', 'DESC').addOrderBy('split.id', 'DESC');
+        break;
+    }
+
+    return queryBuilder;
+  }
+
+  /**
+   * Get total count of filtered results
+   * I'm caching this in a separate query to avoid affecting the main query performance
+   */
+  private async getFilteredCount(dto: SearchSplitsDto): Promise<number> {
+    const searchQuery = this.sanitizeSearchQuery(dto.query);
+    
+    let countBuilder = this.splitRepository.createQueryBuilder('split');
+
+    if (searchQuery.trim()) {
+      const tsQuery = this.buildTsQuery(searchQuery);
+      countBuilder.andWhere(`(
+        to_tsvector('english', COALESCE(split.description, '')) @@ to_tsquery('english', :tsQuery)
+        OR similarity(COALESCE(split.description, ''), :rawQuery) > :threshold
+        OR EXISTS (
+          SELECT 1 FROM items i 
+          WHERE i."splitId" = split.id 
+          AND (
+            to_tsvector('english', i.name) @@ to_tsquery('english', :tsQuery)
+            OR similarity(i.name, :rawQuery) > :threshold
+          )
+        )
+      )`, { 
+        tsQuery, 
+        rawQuery: searchQuery,
+        threshold: this.FUZZY_THRESHOLD 
+      });
+    }
+
+    if (dto.filters) {
+      countBuilder = this.applyFilters(countBuilder, dto.filters);
+    }
+
+    return countBuilder.getCount();
+  }
+
+  /**
+   * Build search results with highlighted matches
+   */
+  private async buildSearchResults(
+    splits: Split[],
+    searchQuery: string,
+  ): Promise<SearchResultItemDto[]> {
+    const results: SearchResultItemDto[] = [];
+
+    for (const split of splits) {
+      const highlights = this.generateHighlights(split, searchQuery);
+      const score = this.calculateRelevanceScore(split, searchQuery);
+
+      results.push({
+        split,
+        highlights,
+        score,
+      });
+    }
+
+    // Sort by relevance score if we have a search query
+    if (searchQuery.trim()) {
+      results.sort((a, b) => b.score - a.score);
+    }
+
+    return results;
+  }
+
+  /**
+   * Generate highlighted snippets for matched content
+   * I'm using a simple approach here - wrapping matched terms in <mark> tags
+   */
+  private generateHighlights(split: Split, searchQuery: string): SearchHighlightsDto {
+    const highlights: SearchHighlightsDto = {};
+    const terms = searchQuery.toLowerCase().split(/\s+/).filter(t => t.length > 0);
+
+    // Highlight description
+    if (split.description) {
+      let highlightedDesc = split.description;
+      for (const term of terms) {
+        const regex = new RegExp(`(${this.escapeRegex(term)})`, 'gi');
+        highlightedDesc = highlightedDesc.replace(regex, '<mark>$1</mark>');
+      }
+      if (highlightedDesc !== split.description) {
+        highlights.description = highlightedDesc;
+      }
+    }
+
+    // Highlight matching item names
+    if (split.items && split.items.length > 0) {
+      const matchedItems: string[] = [];
+      for (const item of split.items) {
+        const itemNameLower = item.name.toLowerCase();
+        for (const term of terms) {
+          if (itemNameLower.includes(term)) {
+            const regex = new RegExp(`(${this.escapeRegex(term)})`, 'gi');
+            matchedItems.push(item.name.replace(regex, '<mark>$1</mark>'));
+            break;
+          }
+        }
+      }
+      if (matchedItems.length > 0) {
+        highlights.itemNames = matchedItems;
+      }
+    }
+
+    return highlights;
+  }
+
+  /**
+   * Calculate a simple relevance score for client-side sorting
+   */
+  private calculateRelevanceScore(split: Split, searchQuery: string): number {
+    if (!searchQuery.trim()) return 1;
+
+    const terms = searchQuery.toLowerCase().split(/\s+/).filter(t => t.length > 0);
+    let score = 0;
+
+    // Score based on description matches
+    if (split.description) {
+      const descLower = split.description.toLowerCase();
+      for (const term of terms) {
+        if (descLower.includes(term)) {
+          score += 0.5;
+          // Bonus for exact word match
+          if (new RegExp(`\\b${this.escapeRegex(term)}\\b`, 'i').test(split.description)) {
+            score += 0.3;
+          }
+        }
+      }
+    }
+
+    // Score based on item name matches
+    if (split.items) {
+      for (const item of split.items) {
+        const itemNameLower = item.name.toLowerCase();
+        for (const term of terms) {
+          if (itemNameLower.includes(term)) {
+            score += 0.3;
+          }
+        }
+      }
+    }
+
+    return Math.min(score, 1); // Normalize to 0-1
+  }
+
+  /**
+   * Convert user query to PostgreSQL tsquery format
+   * Handling special characters and multi-word queries
+   */
+  private buildTsQuery(query: string): string {
+    // Split into words, remove special characters, join with &
+    const words = query
+      .replace(/[^\w\s]/g, ' ')
+      .split(/\s+/)
+      .filter(word => word.length > 0)
+      .map(word => `${word}:*`); // Prefix matching for partial words
+
+    return words.join(' & ') || '';
+  }
+
+  /**
+   * Sanitize search query to prevent SQL injection
+   * Even though we use parameterized queries, this adds extra safety
+   */
+  private sanitizeSearchQuery(query: string): string {
+    return query
+      .replace(/[<>]/g, '') // Remove potential HTML
+      .slice(0, 200) // Limit length
+      .trim();
+  }
+
+  /**
+   * Encode cursor for pagination
+   */
+  private encodeCursor(split: Split): string {
+    const cursor: DecodedCursor = {
+      createdAt: split.createdAt.toISOString(),
+      id: split.id,
+    };
+    return Buffer.from(JSON.stringify(cursor)).toString('base64');
+  }
+
+  /**
+   * Decode cursor from base64
+   */
+  private decodeCursor(cursorString: string): DecodedCursor | null {
+    try {
+      const decoded = Buffer.from(cursorString, 'base64').toString('utf-8');
+      return JSON.parse(decoded) as DecodedCursor;
+    } catch (error) {
+      this.logger.warn(`Failed to decode cursor: ${cursorString}`);
+      return null;
+    }
+  }
+
+  /**
+   * Escape special regex characters
+   */
+  private escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+}


### PR DESCRIPTION
- I added a SearchModule with full-text search using PostgreSQL to_tsvector/to_tsquery
- I implemented fuzzy matching with pg_trgm extension for typo tolerance
- I added advanced filters: date ranges, amount ranges, status, participants
- I implemented cursor-based pagination for stable infinite scroll
- I added result highlighting with <mark> tags for matched terms
- I included relevance scoring for search result ranking
- I added a database migration for search indexes (GIN, trigram, composite)
- I included 22 unit tests for service and controller


**~backend$** `npm run test -- --testPathPattern=search --verbose`
<img width="639" height="641" alt="image" src="https://github.com/user-attachments/assets/f6d5d524-d701-40ea-8a3b-334973949b41" />


Closes #55