### PR TITLE
feat(webhooks): add webhook CRUD, delivery queue, retries, and HMAC 

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -19,6 +19,7 @@ import { SplitHistoryModule } from "./split-history/split-history.module";
 import { ActivitiesModule } from "./modules/activities/activities.module";
 import { SearchModule } from "./search/search.module";
 import { AnalyticsModule } from "./analytics/analytics.module";
+import { WebhooksModule } from "./webhooks/webhooks.module";
 // Load environment variables
 dotenv.config({
   path: path.resolve(__dirname, "../.env"),
@@ -71,6 +72,8 @@ dotenv.config({
     SearchModule,
     // Analytics module for user spending & reports
     AnalyticsModule,
+    // Webhooks module for external event notifications
+    WebhooksModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/database/data-source.ts
+++ b/backend/src/database/data-source.ts
@@ -14,7 +14,10 @@ export const AppDataSource = new DataSource({
     password: process.env.DB_PASSWORD || 'postgres',
     database: process.env.DB_NAME || 'stellarsplit_dev',
     entities: [path.join(__dirname, '../entities/*.entity{.ts,.js}')],
-    migrations: [path.join(__dirname, '../database/migrations/*{.ts,.js}')],
+    migrations: [
+        path.join(__dirname, 'migrations/*{.ts,.js}'),
+        path.join(__dirname, '../migrations/*{.ts,.js}'),
+    ],
     synchronize: false, // Should be false for migrations
     logging: true,
 });

--- a/backend/src/migrations/1738200000000-CreateWebhooksTables.ts
+++ b/backend/src/migrations/1738200000000-CreateWebhooksTables.ts
@@ -1,0 +1,217 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex, TableForeignKey } from "typeorm";
+
+export class CreateWebhooksTables1738200000000 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Create webhooks table
+        await queryRunner.createTable(
+            new Table({
+                name: "webhooks",
+                columns: [
+                    {
+                        name: "id",
+                        type: "uuid",
+                        isPrimary: true,
+                        default: "gen_random_uuid()",
+                    },
+                    {
+                        name: "userId",
+                        type: "varchar",
+                        isNullable: false,
+                    },
+                    {
+                        name: "url",
+                        type: "varchar",
+                        length: "500",
+                        isNullable: false,
+                    },
+                    {
+                        name: "events",
+                        type: "jsonb",
+                        default: "'[]'",
+                        isNullable: false,
+                    },
+                    {
+                        name: "secret",
+                        type: "varchar",
+                        length: "255",
+                        isNullable: false,
+                    },
+                    {
+                        name: "isActive",
+                        type: "boolean",
+                        default: true,
+                        isNullable: false,
+                    },
+                    {
+                        name: "failureCount",
+                        type: "integer",
+                        default: 0,
+                        isNullable: false,
+                    },
+                    {
+                        name: "lastTriggeredAt",
+                        type: "timestamp",
+                        isNullable: true,
+                    },
+                    {
+                        name: "createdAt",
+                        type: "timestamp",
+                        default: "CURRENT_TIMESTAMP",
+                        isNullable: false,
+                    },
+                    {
+                        name: "updatedAt",
+                        type: "timestamp",
+                        default: "CURRENT_TIMESTAMP",
+                        isNullable: false,
+                    },
+                ],
+            }),
+            true,
+        );
+
+        // Create webhook_deliveries table
+        await queryRunner.createTable(
+            new Table({
+                name: "webhook_deliveries",
+                columns: [
+                    {
+                        name: "id",
+                        type: "uuid",
+                        isPrimary: true,
+                        default: "gen_random_uuid()",
+                    },
+                    {
+                        name: "webhookId",
+                        type: "uuid",
+                        isNullable: false,
+                    },
+                    {
+                        name: "eventType",
+                        type: "varchar",
+                        isNullable: false,
+                    },
+                    {
+                        name: "payload",
+                        type: "jsonb",
+                        isNullable: false,
+                    },
+                    {
+                        name: "status",
+                        type: "enum",
+                        enum: ["pending", "success", "failed"],
+                        default: "'pending'",
+                        isNullable: false,
+                    },
+                    {
+                        name: "attemptCount",
+                        type: "integer",
+                        default: 0,
+                        isNullable: false,
+                    },
+                    {
+                        name: "httpStatus",
+                        type: "integer",
+                        isNullable: true,
+                    },
+                    {
+                        name: "responseBody",
+                        type: "text",
+                        isNullable: true,
+                    },
+                    {
+                        name: "errorMessage",
+                        type: "text",
+                        isNullable: true,
+                    },
+                    {
+                        name: "deliveredAt",
+                        type: "timestamp",
+                        isNullable: true,
+                    },
+                    {
+                        name: "createdAt",
+                        type: "timestamp",
+                        default: "CURRENT_TIMESTAMP",
+                        isNullable: false,
+                    },
+                ],
+            }),
+            true,
+        );
+
+        // Create foreign key for webhook_deliveries
+        await queryRunner.createForeignKey(
+            "webhook_deliveries",
+            new TableForeignKey({
+                columnNames: ["webhookId"],
+                referencedColumnNames: ["id"],
+                referencedTableName: "webhooks",
+                onDelete: "CASCADE",
+            }),
+        );
+
+        // Create indexes for webhooks table
+        await queryRunner.createIndex(
+            "webhooks",
+            new TableIndex({
+                name: "idx_webhooks_userId",
+                columnNames: ["userId"],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            "webhooks",
+            new TableIndex({
+                name: "idx_webhooks_isActive",
+                columnNames: ["isActive"],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            "webhooks",
+            new TableIndex({
+                name: "idx_webhooks_userId_isActive",
+                columnNames: ["userId", "isActive"],
+            }),
+        );
+
+        // Create indexes for webhook_deliveries table
+        await queryRunner.createIndex(
+            "webhook_deliveries",
+            new TableIndex({
+                name: "idx_webhook_deliveries_webhookId",
+                columnNames: ["webhookId"],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            "webhook_deliveries",
+            new TableIndex({
+                name: "idx_webhook_deliveries_status",
+                columnNames: ["status"],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            "webhook_deliveries",
+            new TableIndex({
+                name: "idx_webhook_deliveries_webhookId_status",
+                columnNames: ["webhookId", "status"],
+            }),
+        );
+
+        await queryRunner.createIndex(
+            "webhook_deliveries",
+            new TableIndex({
+                name: "idx_webhook_deliveries_createdAt",
+                columnNames: ["createdAt"],
+            }),
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("webhook_deliveries", true);
+        await queryRunner.dropTable("webhooks", true);
+    }
+}

--- a/backend/src/webhooks/dto/create-webhook.dto.ts
+++ b/backend/src/webhooks/dto/create-webhook.dto.ts
@@ -1,0 +1,39 @@
+import { IsString, IsUrl, IsArray, IsNotEmpty, ArrayNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookEventType } from '../webhook.entity';
+
+export class CreateWebhookDto {
+  @ApiProperty({
+    description: 'User ID who owns this webhook',
+    example: 'user-123',
+  })
+  @IsString()
+  @IsNotEmpty()
+  userId!: string;
+
+  @ApiProperty({
+    description: 'Webhook endpoint URL',
+    example: 'https://example.com/webhooks',
+  })
+  @IsUrl({ require_protocol: true })
+  @IsNotEmpty()
+  url!: string;
+
+  @ApiProperty({
+    description: 'Array of event types to subscribe to',
+    enum: WebhookEventType,
+    isArray: true,
+    example: [WebhookEventType.SPLIT_CREATED, WebhookEventType.PAYMENT_RECEIVED],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  events!: WebhookEventType[];
+
+  @ApiProperty({
+    description: 'Secret key for HMAC signature verification',
+    example: 'your-secret-key-here',
+  })
+  @IsString()
+  @IsNotEmpty()
+  secret!: string;
+}

--- a/backend/src/webhooks/dto/test-webhook.dto.ts
+++ b/backend/src/webhooks/dto/test-webhook.dto.ts
@@ -1,0 +1,22 @@
+import { IsString, IsNotEmpty, IsObject, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookEventType } from '../webhook.entity';
+
+export class TestWebhookDto {
+  @ApiProperty({
+    description: 'Event type to test',
+    enum: WebhookEventType,
+    example: WebhookEventType.SPLIT_CREATED,
+  })
+  @IsString()
+  @IsNotEmpty()
+  eventType!: WebhookEventType;
+
+  @ApiProperty({
+    description: 'Optional custom payload to send',
+    required: false,
+  })
+  @IsObject()
+  @IsOptional()
+  payload?: Record<string, any>;
+}

--- a/backend/src/webhooks/dto/update-webhook.dto.ts
+++ b/backend/src/webhooks/dto/update-webhook.dto.ts
@@ -1,0 +1,40 @@
+import { IsString, IsUrl, IsArray, IsBoolean, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { WebhookEventType } from '../webhook.entity';
+
+export class UpdateWebhookDto {
+  @ApiProperty({
+    description: 'Webhook endpoint URL',
+    example: 'https://example.com/webhooks',
+    required: false,
+  })
+  @IsUrl({ require_protocol: true })
+  @IsOptional()
+  url?: string;
+
+  @ApiProperty({
+    description: 'Array of event types to subscribe to',
+    enum: WebhookEventType,
+    isArray: true,
+    required: false,
+  })
+  @IsArray()
+  @IsOptional()
+  events?: WebhookEventType[];
+
+  @ApiProperty({
+    description: 'Secret key for HMAC signature verification',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  secret?: string;
+
+  @ApiProperty({
+    description: 'Whether the webhook is active',
+    required: false,
+  })
+  @IsBoolean()
+  @IsOptional()
+  isActive?: boolean;
+}

--- a/backend/src/webhooks/webhook-delivery.entity.ts
+++ b/backend/src/webhooks/webhook-delivery.entity.ts
@@ -1,0 +1,66 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  ManyToOne,
+  JoinColumn,
+  Index,
+} from 'typeorm';
+import { Webhook } from './webhook.entity';
+
+export enum DeliveryStatus {
+  PENDING = 'pending',
+  SUCCESS = 'success',
+  FAILED = 'failed',
+}
+
+@Entity('webhook_deliveries')
+@Index(['webhookId'])
+@Index(['status'])
+@Index(['webhookId', 'status'])
+@Index(['createdAt'])
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  webhookId!: string;
+
+  @Column({ type: 'varchar' })
+  eventType!: string;
+
+  @Column({ type: 'jsonb' })
+  payload!: Record<string, any>;
+
+  @Column({
+    type: 'enum',
+    enum: DeliveryStatus,
+    default: DeliveryStatus.PENDING,
+  })
+  status!: DeliveryStatus;
+
+  @Column({ type: 'integer', default: 0 })
+  attemptCount!: number;
+
+  @Column({ type: 'integer', nullable: true })
+  httpStatus?: number;
+
+  @Column({ type: 'text', nullable: true })
+  responseBody?: string;
+
+  @Column({ type: 'text', nullable: true })
+  errorMessage?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  deliveredAt?: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @ManyToOne(() => Webhook, (webhook) => webhook.deliveries, {
+    onDelete: 'CASCADE',
+  })
+  @JoinColumn({ name: 'webhookId' })
+  webhook?: Webhook;
+}

--- a/backend/src/webhooks/webhook-delivery.service.spec.ts
+++ b/backend/src/webhooks/webhook-delivery.service.spec.ts
@@ -1,0 +1,169 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { getQueueToken } from '@nestjs/bull';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery, DeliveryStatus } from './webhook-delivery.entity';
+import { WebhookEventType } from './webhook.entity';
+
+describe('WebhookDeliveryService', () => {
+  let service: WebhookDeliveryService;
+  let webhookRepository: Repository<Webhook>;
+  let deliveryRepository: Repository<WebhookDelivery>;
+  let webhookQueue: any;
+
+  const mockWebhookRepository = {
+    createQueryBuilder: jest.fn(),
+    findOne: jest.fn(),
+    save: jest.fn(),
+  };
+
+  const mockDeliveryRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+  };
+
+  const mockQueue = {
+    add: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhookDeliveryService,
+        {
+          provide: getRepositoryToken(Webhook),
+          useValue: mockWebhookRepository,
+        },
+        {
+          provide: getRepositoryToken(WebhookDelivery),
+          useValue: mockDeliveryRepository,
+        },
+        {
+          provide: getQueueToken('webhook_queue'),
+          useValue: mockQueue,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhookDeliveryService>(WebhookDeliveryService);
+    webhookRepository = module.get<Repository<Webhook>>(
+      getRepositoryToken(Webhook),
+    );
+    deliveryRepository = module.get<Repository<WebhookDelivery>>(
+      getRepositoryToken(WebhookDelivery),
+    );
+    webhookQueue = module.get(getQueueToken('webhook_queue'));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('triggerEvent', () => {
+    it('should queue delivery for active webhooks subscribed to event', async () => {
+      const webhooks = [
+        {
+          id: 'webhook-1',
+          userId: 'user-1',
+          url: 'https://example.com/webhook',
+          events: [WebhookEventType.SPLIT_CREATED],
+          secret: 'secret-1',
+          isActive: true,
+        },
+      ];
+
+      const queryBuilder = {
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue(webhooks),
+      };
+
+      mockWebhookRepository.createQueryBuilder.mockReturnValue(queryBuilder);
+      mockDeliveryRepository.create.mockReturnValue({
+        id: 'delivery-1',
+        webhookId: 'webhook-1',
+        eventType: WebhookEventType.SPLIT_CREATED,
+        payload: {},
+        status: DeliveryStatus.PENDING,
+      });
+      mockDeliveryRepository.save.mockResolvedValue({
+        id: 'delivery-1',
+      });
+      mockQueue.add.mockResolvedValue({});
+
+      await service.triggerEvent(
+        WebhookEventType.SPLIT_CREATED,
+        { test: 'data' },
+        'user-1',
+      );
+
+      expect(mockDeliveryRepository.create).toHaveBeenCalled();
+      expect(mockDeliveryRepository.save).toHaveBeenCalled();
+      expect(mockQueue.add).toHaveBeenCalled();
+    });
+  });
+
+  describe('getDeliveryLogs', () => {
+    it('should return delivery logs for a webhook', async () => {
+      const deliveries = [
+        {
+          id: 'delivery-1',
+          webhookId: 'webhook-1',
+          status: DeliveryStatus.SUCCESS,
+        },
+        {
+          id: 'delivery-2',
+          webhookId: 'webhook-1',
+          status: DeliveryStatus.FAILED,
+        },
+      ];
+
+      mockDeliveryRepository.find.mockResolvedValue(deliveries);
+
+      const result = await service.getDeliveryLogs('webhook-1', 50);
+
+      expect(mockDeliveryRepository.find).toHaveBeenCalledWith({
+        where: { webhookId: 'webhook-1' },
+        order: { createdAt: 'DESC' },
+        take: 50,
+      });
+      expect(result).toEqual(deliveries);
+    });
+  });
+
+  describe('getDeliveryStats', () => {
+    it('should calculate delivery statistics correctly', async () => {
+      const deliveries = [
+        {
+          id: 'delivery-1',
+          status: DeliveryStatus.SUCCESS,
+        },
+        {
+          id: 'delivery-2',
+          status: DeliveryStatus.SUCCESS,
+        },
+        {
+          id: 'delivery-3',
+          status: DeliveryStatus.FAILED,
+        },
+        {
+          id: 'delivery-4',
+          status: DeliveryStatus.PENDING,
+        },
+      ];
+
+      mockDeliveryRepository.find.mockResolvedValue(deliveries);
+
+      const result = await service.getDeliveryStats('webhook-1');
+
+      expect(result.total).toBe(4);
+      expect(result.success).toBe(2);
+      expect(result.failed).toBe(1);
+      expect(result.pending).toBe(1);
+      expect(result.successRate).toBe(50);
+    });
+  });
+});

--- a/backend/src/webhooks/webhook-delivery.service.ts
+++ b/backend/src/webhooks/webhook-delivery.service.ts
@@ -1,0 +1,327 @@
+import {
+  Injectable,
+  Logger,
+  BadRequestException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { InjectQueue } from '@nestjs/bull';
+import { Queue } from 'bull';
+import axios, { AxiosRequestConfig } from 'axios';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery, DeliveryStatus } from './webhook-delivery.entity';
+import { WebhookEventType } from './webhook.entity';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class WebhookDeliveryService {
+  private readonly logger = new Logger(WebhookDeliveryService.name);
+  private readonly TIMEOUT_MS = 5000; // 5 seconds
+  private readonly MAX_RETRIES = 3;
+  private readonly RATE_LIMIT_WINDOW_MS = 60000; // 1 minute
+  private readonly MAX_REQUESTS_PER_WINDOW = 10;
+
+  // In-memory rate limiting per webhook
+  private rateLimitMap = new Map<string, { count: number; resetAt: number }>();
+
+  constructor(
+    @InjectRepository(Webhook)
+    private readonly webhookRepository: Repository<Webhook>,
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepository: Repository<WebhookDelivery>,
+    @InjectQueue('webhook_queue')
+    private readonly webhookQueue: Queue,
+  ) {}
+
+  /**
+   * Trigger webhook delivery for a specific event
+   */
+  async triggerEvent(
+    eventType: WebhookEventType,
+    payload: Record<string, any>,
+    userId?: string,
+  ): Promise<void> {
+    // Find all active webhooks subscribed to this event
+    const webhooks = await this.webhookRepository
+      .createQueryBuilder('webhook')
+      .where('webhook.isActive = :isActive', { isActive: true })
+      .andWhere('webhook.events @> :event', {
+        event: JSON.stringify([eventType]),
+      })
+      .getMany();
+
+    // Filter by userId if provided
+    const filteredWebhooks = userId
+      ? webhooks.filter((w) => w.userId === userId)
+      : webhooks;
+
+    this.logger.log(
+      `Triggering ${eventType} event for ${filteredWebhooks.length} webhook(s)`,
+    );
+
+    // Queue delivery for each webhook
+    for (const webhook of filteredWebhooks) {
+      await this.queueDelivery(webhook, eventType, payload);
+    }
+  }
+
+  /**
+   * Queue a webhook delivery job
+   */
+  private async queueDelivery(
+    webhook: Webhook,
+    eventType: WebhookEventType,
+    payload: Record<string, any>,
+  ): Promise<void> {
+    // Check rate limiting
+    if (!this.checkRateLimit(webhook.id)) {
+      this.logger.warn(
+        `Rate limit exceeded for webhook ${webhook.id}. Skipping delivery.`,
+      );
+      return;
+    }
+
+    // Create delivery record
+    const delivery = this.deliveryRepository.create({
+      webhookId: webhook.id,
+      eventType,
+      payload,
+      status: DeliveryStatus.PENDING,
+      attemptCount: 0,
+    });
+
+    const savedDelivery = await this.deliveryRepository.save(delivery);
+
+    // Add to queue with retry configuration
+    await this.webhookQueue.add(
+      'deliver',
+      {
+        deliveryId: savedDelivery.id,
+        webhookId: webhook.id,
+        url: webhook.url,
+        secret: webhook.secret,
+        eventType,
+        payload,
+      },
+      {
+        attempts: this.MAX_RETRIES,
+        backoff: {
+          type: 'exponential',
+          delay: 1000, // Start with 1 second, exponential backoff
+        },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    );
+  }
+
+  /**
+   * Process a webhook delivery job
+   */
+  async processDelivery(jobData: {
+    deliveryId: string;
+    webhookId: string;
+    url: string;
+    secret: string;
+    eventType: string;
+    payload: Record<string, any>;
+  }): Promise<void> {
+    const { deliveryId, webhookId, url, secret, eventType, payload } = jobData;
+
+    this.logger.log(
+      `Processing webhook delivery ${deliveryId} for webhook ${webhookId}`,
+    );
+
+    const delivery = await this.deliveryRepository.findOne({
+      where: { id: deliveryId },
+    });
+
+    if (!delivery) {
+      throw new BadRequestException(`Delivery ${deliveryId} not found`);
+    }
+
+    // Increment attempt count
+    delivery.attemptCount += 1;
+    await this.deliveryRepository.save(delivery);
+
+    try {
+      // Generate HMAC signature
+      const signature = this.generateSignature(JSON.stringify(payload), secret);
+      const timestamp = Date.now();
+
+      // Make HTTP request with timeout
+      const requestBody = {
+        event: eventType,
+        data: payload,
+        timestamp,
+      };
+
+      const axiosConfig: AxiosRequestConfig = {
+        method: 'POST',
+        url,
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Webhook-Signature': signature,
+          'X-Webhook-Timestamp': timestamp.toString(),
+          'X-Webhook-Event': eventType,
+        },
+        data: requestBody,
+        timeout: this.TIMEOUT_MS,
+        validateStatus: () => true, // Don't throw on any status code
+      };
+
+      const response = await axios(axiosConfig);
+
+      // Update delivery record
+      delivery.status =
+        response.status >= 200 && response.status < 300
+          ? DeliveryStatus.SUCCESS
+          : DeliveryStatus.FAILED;
+      delivery.httpStatus = response.status;
+      delivery.deliveredAt = new Date();
+
+      if (response.status >= 200 && response.status < 300) {
+        const responseText =
+          typeof response.data === 'string'
+            ? response.data
+            : JSON.stringify(response.data);
+        delivery.responseBody = responseText.substring(0, 1000); // Limit size
+        this.logger.log(`Webhook delivery ${deliveryId} succeeded`);
+      } else {
+        const responseText =
+          typeof response.data === 'string'
+            ? response.data
+            : JSON.stringify(response.data);
+        delivery.responseBody = responseText.substring(0, 1000);
+        delivery.errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+        this.logger.warn(
+          `Webhook delivery ${deliveryId} failed with status ${response.status}`,
+        );
+      }
+
+      await this.deliveryRepository.save(delivery);
+
+      // Update webhook stats
+      const webhook = await this.webhookRepository.findOne({
+        where: { id: webhookId },
+      });
+      if (webhook) {
+        if (response.status >= 200 && response.status < 300) {
+          webhook.failureCount = 0;
+          webhook.lastTriggeredAt = new Date();
+        } else {
+          webhook.failureCount += 1;
+          if (webhook.failureCount >= 10) {
+            webhook.isActive = false;
+            this.logger.warn(`Webhook ${webhookId} deactivated due to excessive failures`);
+          }
+        }
+        await this.webhookRepository.save(webhook);
+      }
+    } catch (error: any) {
+      this.logger.error(
+        `Webhook delivery ${deliveryId} failed: ${error.message}`,
+      );
+
+      delivery.status = DeliveryStatus.FAILED;
+      delivery.errorMessage = error.message?.substring(0, 500);
+
+      await this.deliveryRepository.save(delivery);
+
+      // Update webhook failure count
+      const webhook = await this.webhookRepository.findOne({
+        where: { id: webhookId },
+      });
+      if (webhook && delivery.attemptCount >= this.MAX_RETRIES) {
+        webhook.failureCount += 1;
+        if (webhook.failureCount >= 10) {
+          webhook.isActive = false;
+          this.logger.warn(`Webhook ${webhookId} deactivated due to excessive failures`);
+        }
+        await this.webhookRepository.save(webhook);
+      }
+
+      // Re-throw to trigger retry
+      throw error;
+    }
+  }
+
+  /**
+   * Generate HMAC-SHA256 signature
+   */
+  private generateSignature(payload: string, secret: string): string {
+    return crypto.createHmac('sha256', secret).update(payload).digest('hex');
+  }
+
+  /**
+   * Check rate limiting for a webhook
+   */
+  private checkRateLimit(webhookId: string): boolean {
+    const now = Date.now();
+    const limit = this.rateLimitMap.get(webhookId);
+
+    if (!limit || now > limit.resetAt) {
+      // Reset or initialize
+      this.rateLimitMap.set(webhookId, {
+        count: 1,
+        resetAt: now + this.RATE_LIMIT_WINDOW_MS,
+      });
+      return true;
+    }
+
+    if (limit.count >= this.MAX_REQUESTS_PER_WINDOW) {
+      return false;
+    }
+
+    limit.count += 1;
+    return true;
+  }
+
+  /**
+   * Get delivery logs for a webhook
+   */
+  async getDeliveryLogs(
+    webhookId: string,
+    limit: number = 50,
+  ): Promise<WebhookDelivery[]> {
+    return await this.deliveryRepository.find({
+      where: { webhookId },
+      order: { createdAt: 'DESC' },
+      take: limit,
+    });
+  }
+
+  /**
+   * Get delivery statistics for a webhook
+   */
+  async getDeliveryStats(webhookId: string): Promise<{
+    total: number;
+    success: number;
+    failed: number;
+    pending: number;
+    successRate: number;
+  }> {
+    const deliveries = await this.deliveryRepository.find({
+      where: { webhookId },
+    });
+
+    const total = deliveries.length;
+    const success = deliveries.filter(
+      (d) => d.status === DeliveryStatus.SUCCESS,
+    ).length;
+    const failed = deliveries.filter(
+      (d) => d.status === DeliveryStatus.FAILED,
+    ).length;
+    const pending = deliveries.filter(
+      (d) => d.status === DeliveryStatus.PENDING,
+    ).length;
+
+    return {
+      total,
+      success,
+      failed,
+      pending,
+      successRate: total > 0 ? (success / total) * 100 : 0,
+    };
+  }
+}

--- a/backend/src/webhooks/webhook.entity.ts
+++ b/backend/src/webhooks/webhook.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  OneToMany,
+} from 'typeorm';
+import { WebhookDelivery } from './webhook-delivery.entity';
+
+export enum WebhookEventType {
+  SPLIT_CREATED = 'split.created',
+  SPLIT_UPDATED = 'split.updated',
+  SPLIT_COMPLETED = 'split.completed',
+  PAYMENT_RECEIVED = 'payment.received',
+  PAYMENT_MADE = 'payment.made',
+  PARTICIPANT_ADDED = 'participant.added',
+}
+
+@Entity('webhooks')
+@Index(['userId'])
+@Index(['isActive'])
+@Index(['userId', 'isActive'])
+export class Webhook {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'varchar' })
+  @Index()
+  userId!: string;
+
+  @Column({ type: 'varchar', length: 500 })
+  url!: string;
+
+  @Column({ type: 'jsonb', default: [] })
+  events!: WebhookEventType[];
+
+  @Column({ type: 'varchar', length: 255 })
+  secret!: string;
+
+  @Column({ type: 'boolean', default: true })
+  isActive!: boolean;
+
+  @Column({ type: 'integer', default: 0 })
+  failureCount!: number;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastTriggeredAt?: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @OneToMany(() => WebhookDelivery, (delivery) => delivery.webhook)
+  deliveries?: WebhookDelivery[];
+}

--- a/backend/src/webhooks/webhook.processor.ts
+++ b/backend/src/webhooks/webhook.processor.ts
@@ -1,0 +1,28 @@
+import { Process, Processor } from '@nestjs/bull';
+import { Logger } from '@nestjs/common';
+import { Job } from 'bull';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+
+@Processor('webhook_queue')
+export class WebhookProcessor {
+  private readonly logger = new Logger(WebhookProcessor.name);
+
+  constructor(
+    private readonly deliveryService: WebhookDeliveryService,
+  ) {}
+
+  @Process('deliver')
+  async handleDelivery(job: Job<any>) {
+    this.logger.log(`Processing webhook delivery job ${job.id}`);
+    
+    try {
+      await this.deliveryService.processDelivery(job.data);
+      this.logger.log(`Webhook delivery job ${job.id} completed successfully`);
+    } catch (error: any) {
+      this.logger.error(
+        `Webhook delivery job ${job.id} failed: ${error.message}`,
+      );
+      throw error; // Re-throw to trigger retry
+    }
+  }
+}

--- a/backend/src/webhooks/webhooks.controller.spec.ts
+++ b/backend/src/webhooks/webhooks.controller.spec.ts
@@ -1,0 +1,203 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { TestWebhookDto } from './dto/test-webhook.dto';
+import { WebhookEventType } from './webhook.entity';
+
+describe('WebhooksController', () => {
+  let controller: WebhooksController;
+  let webhooksService: WebhooksService;
+  let deliveryService: WebhookDeliveryService;
+
+  const mockWebhooksService = {
+    create: jest.fn(),
+    findAll: jest.fn(),
+    findOne: jest.fn(),
+    update: jest.fn(),
+    remove: jest.fn(),
+  };
+
+  const mockDeliveryService = {
+    triggerEvent: jest.fn(),
+    getDeliveryLogs: jest.fn(),
+    getDeliveryStats: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [WebhooksController],
+      providers: [
+        {
+          provide: WebhooksService,
+          useValue: mockWebhooksService,
+        },
+        {
+          provide: WebhookDeliveryService,
+          useValue: mockDeliveryService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get<WebhooksController>(WebhooksController);
+    webhooksService = module.get<WebhooksService>(WebhooksService);
+    deliveryService = module.get<WebhookDeliveryService>(
+      WebhookDeliveryService,
+    );
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a webhook', async () => {
+      const createDto: CreateWebhookDto = {
+        userId: 'user-123',
+        url: 'https://example.com/webhook',
+        events: [WebhookEventType.SPLIT_CREATED],
+        secret: 'test-secret',
+      };
+
+      const webhook = { id: 'webhook-123', ...createDto };
+
+      mockWebhooksService.create.mockResolvedValue(webhook);
+
+      const result = await controller.create(createDto);
+
+      expect(mockWebhooksService.create).toHaveBeenCalledWith(createDto);
+      expect(result).toEqual(webhook);
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all webhooks', async () => {
+      const webhooks = [{ id: 'webhook-1' }, { id: 'webhook-2' }];
+
+      mockWebhooksService.findAll.mockResolvedValue(webhooks);
+
+      const result = await controller.findAll();
+
+      expect(mockWebhooksService.findAll).toHaveBeenCalled();
+      expect(result).toEqual(webhooks);
+    });
+
+    it('should filter by userId when provided', async () => {
+      const webhooks = [{ id: 'webhook-1', userId: 'user-1' }];
+
+      mockWebhooksService.findAll.mockResolvedValue(webhooks);
+
+      const result = await controller.findAll('user-1');
+
+      expect(mockWebhooksService.findAll).toHaveBeenCalledWith('user-1');
+      expect(result).toEqual(webhooks);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a webhook by id', async () => {
+      const webhook = { id: 'webhook-123' };
+
+      mockWebhooksService.findOne.mockResolvedValue(webhook);
+
+      const result = await controller.findOne('webhook-123');
+
+      expect(mockWebhooksService.findOne).toHaveBeenCalledWith('webhook-123');
+      expect(result).toEqual(webhook);
+    });
+  });
+
+  describe('update', () => {
+    it('should update a webhook', async () => {
+      const updateDto: UpdateWebhookDto = {
+        url: 'https://newurl.com/webhook',
+      };
+
+      const webhook = { id: 'webhook-123', ...updateDto };
+
+      mockWebhooksService.update.mockResolvedValue(webhook);
+
+      const result = await controller.update('webhook-123', updateDto);
+
+      expect(mockWebhooksService.update).toHaveBeenCalledWith(
+        'webhook-123',
+        updateDto,
+      );
+      expect(result).toEqual(webhook);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a webhook', async () => {
+      mockWebhooksService.remove.mockResolvedValue(undefined);
+
+      await controller.remove('webhook-123');
+
+      expect(mockWebhooksService.remove).toHaveBeenCalledWith('webhook-123');
+    });
+  });
+
+  describe('testWebhook', () => {
+    it('should trigger a test webhook', async () => {
+      const testDto: TestWebhookDto = {
+        eventType: WebhookEventType.SPLIT_CREATED,
+        payload: { test: true },
+      };
+
+      const webhook = {
+        id: 'webhook-123',
+        userId: 'user-1',
+      };
+
+      mockWebhooksService.findOne.mockResolvedValue(webhook);
+      mockDeliveryService.triggerEvent.mockResolvedValue(undefined);
+
+      const result = await controller.testWebhook('webhook-123', testDto);
+
+      expect(mockWebhooksService.findOne).toHaveBeenCalledWith('webhook-123');
+      expect(mockDeliveryService.triggerEvent).toHaveBeenCalled();
+      expect(result.message).toBe('Test webhook triggered');
+    });
+  });
+
+  describe('getDeliveries', () => {
+    it('should return delivery logs', async () => {
+      const deliveries = [{ id: 'delivery-1' }, { id: 'delivery-2' }];
+
+      mockWebhooksService.findOne.mockResolvedValue({ id: 'webhook-123' });
+      mockDeliveryService.getDeliveryLogs.mockResolvedValue(deliveries);
+
+      const result = await controller.getDeliveries('webhook-123', 50);
+
+      expect(mockDeliveryService.getDeliveryLogs).toHaveBeenCalledWith(
+        'webhook-123',
+        50,
+      );
+      expect(result).toEqual(deliveries);
+    });
+  });
+
+  describe('getStats', () => {
+    it('should return delivery statistics', async () => {
+      const stats = {
+        total: 100,
+        success: 95,
+        failed: 5,
+        pending: 0,
+        successRate: 95.0,
+      };
+
+      mockWebhooksService.findOne.mockResolvedValue({ id: 'webhook-123' });
+      mockDeliveryService.getDeliveryStats.mockResolvedValue(stats);
+
+      const result = await controller.getStats('webhook-123');
+
+      expect(mockDeliveryService.getDeliveryStats).toHaveBeenCalledWith(
+        'webhook-123',
+      );
+      expect(result).toEqual(stats);
+    });
+  });
+});

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -1,0 +1,182 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+  Query,
+  HttpCode,
+  HttpStatus,
+  ValidationPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { WebhooksService } from './webhooks.service';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { TestWebhookDto } from './dto/test-webhook.dto';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
+
+@ApiTags('Webhooks')
+@Controller('webhooks')
+export class WebhooksController {
+  constructor(
+    private readonly webhooksService: WebhooksService,
+    private readonly deliveryService: WebhookDeliveryService,
+  ) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new webhook' })
+  @ApiResponse({
+    status: 201,
+    description: 'Webhook created successfully',
+    type: Webhook,
+  })
+  @ApiResponse({ status: 400, description: 'Invalid webhook data' })
+  async create(@Body(ValidationPipe) createWebhookDto: CreateWebhookDto) {
+    return await this.webhooksService.create(createWebhookDto);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all webhooks' })
+  @ApiQuery({
+    name: 'userId',
+    required: false,
+    description: 'Filter webhooks by user ID',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of webhooks',
+    type: [Webhook],
+  })
+  async findAll(@Query('userId') userId?: string) {
+    return await this.webhooksService.findAll(userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get a webhook by ID' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Webhook details',
+    type: Webhook,
+  })
+  @ApiResponse({ status: 404, description: 'Webhook not found' })
+  async findOne(@Param('id') id: string) {
+    return await this.webhooksService.findOne(id);
+  }
+
+  @Patch(':id')
+  @ApiOperation({ summary: 'Update a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Webhook updated successfully',
+    type: Webhook,
+  })
+  @ApiResponse({ status: 404, description: 'Webhook not found' })
+  async update(
+    @Param('id') id: string,
+    @Body(ValidationPipe) updateWebhookDto: UpdateWebhookDto,
+  ) {
+    return await this.webhooksService.update(id, updateWebhookDto);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiResponse({ status: 204, description: 'Webhook deleted successfully' })
+  @ApiResponse({ status: 404, description: 'Webhook not found' })
+  async remove(@Param('id') id: string) {
+    await this.webhooksService.remove(id);
+  }
+
+  @Post(':id/test')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Test a webhook with a sample event' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Test webhook triggered successfully',
+  })
+  @ApiResponse({ status: 404, description: 'Webhook not found' })
+  async testWebhook(
+    @Param('id') id: string,
+    @Body(ValidationPipe) testDto: TestWebhookDto,
+  ) {
+    const webhook = await this.webhooksService.findOne(id);
+
+    // Use the delivery service to trigger a test event
+    const payload = testDto.payload || {
+      test: true,
+      message: 'This is a test webhook',
+      timestamp: new Date().toISOString(),
+    };
+
+    await this.deliveryService.triggerEvent(
+      testDto.eventType,
+      payload,
+      webhook.userId,
+    );
+
+    return {
+      message: 'Test webhook triggered',
+      webhookId: id,
+      eventType: testDto.eventType,
+    };
+  }
+
+  @Get(':id/deliveries')
+  @ApiOperation({ summary: 'Get delivery logs for a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiQuery({
+    name: 'limit',
+    required: false,
+    description: 'Maximum number of deliveries to return',
+    type: Number,
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'List of webhook deliveries',
+    type: [WebhookDelivery],
+  })
+  async getDeliveries(
+    @Param('id') id: string,
+    @Query('limit') limit?: number,
+  ) {
+    await this.webhooksService.findOne(id); // Verify webhook exists
+    return await this.deliveryService.getDeliveryLogs(id, limit);
+  }
+
+  @Get(':id/stats')
+  @ApiOperation({ summary: 'Get delivery statistics for a webhook' })
+  @ApiParam({ name: 'id', description: 'Webhook ID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Webhook delivery statistics',
+    schema: {
+      example: {
+        total: 100,
+        success: 95,
+        failed: 5,
+        pending: 0,
+        successRate: 95.0,
+      },
+    },
+  })
+  async getStats(@Param('id') id: string) {
+    await this.webhooksService.findOne(id); // Verify webhook exists
+    return await this.deliveryService.getDeliveryStats(id);
+  }
+}

--- a/backend/src/webhooks/webhooks.module.ts
+++ b/backend/src/webhooks/webhooks.module.ts
@@ -1,0 +1,31 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { BullModule } from '@nestjs/bull';
+import { WebhooksController } from './webhooks.controller';
+import { WebhooksService } from './webhooks.service';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { WebhookProcessor } from './webhook.processor';
+import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Webhook, WebhookDelivery]),
+    BullModule.registerQueue({
+      name: 'webhook_queue',
+      defaultJobOptions: {
+        attempts: 3,
+        backoff: {
+          type: 'exponential',
+          delay: 1000,
+        },
+        removeOnComplete: true,
+        removeOnFail: false,
+      },
+    }),
+  ],
+  controllers: [WebhooksController],
+  providers: [WebhooksService, WebhookDeliveryService, WebhookProcessor],
+  exports: [WebhooksService, WebhookDeliveryService],
+})
+export class WebhooksModule {}

--- a/backend/src/webhooks/webhooks.service.spec.ts
+++ b/backend/src/webhooks/webhooks.service.spec.ts
@@ -1,0 +1,228 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { WebhooksService } from './webhooks.service';
+import { Webhook, WebhookEventType } from './webhook.entity';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
+
+describe('WebhooksService', () => {
+  let service: WebhooksService;
+  let repository: Repository<Webhook>;
+
+  const mockRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    findOne: jest.fn(),
+    remove: jest.fn(),
+    createQueryBuilder: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        WebhooksService,
+        {
+          provide: getRepositoryToken(Webhook),
+          useValue: mockRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<WebhooksService>(WebhooksService);
+    repository = module.get<Repository<Webhook>>(getRepositoryToken(Webhook));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('create', () => {
+    it('should create a webhook successfully', async () => {
+      const createDto: CreateWebhookDto = {
+        userId: 'user-123',
+        url: 'https://example.com/webhook',
+        events: [WebhookEventType.SPLIT_CREATED],
+        secret: 'test-secret',
+      };
+
+      const webhook = {
+        id: 'webhook-123',
+        ...createDto,
+        isActive: true,
+        failureCount: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockRepository.create.mockReturnValue(webhook);
+      mockRepository.save.mockResolvedValue(webhook);
+
+      const result = await service.create(createDto);
+
+      expect(mockRepository.create).toHaveBeenCalledWith({
+        ...createDto,
+        isActive: true,
+        failureCount: 0,
+      });
+      expect(mockRepository.save).toHaveBeenCalled();
+      expect(result).toEqual(webhook);
+    });
+
+    it('should throw BadRequestException for invalid URL', async () => {
+      const createDto: CreateWebhookDto = {
+        userId: 'user-123',
+        url: 'invalid-url',
+        events: [WebhookEventType.SPLIT_CREATED],
+        secret: 'test-secret',
+      };
+
+      await expect(service.create(createDto)).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+  });
+
+  describe('findAll', () => {
+    it('should return all webhooks', async () => {
+      const webhooks = [
+        { id: 'webhook-1', userId: 'user-1' },
+        { id: 'webhook-2', userId: 'user-2' },
+      ];
+
+      mockRepository.find.mockResolvedValue(webhooks);
+
+      const result = await service.findAll();
+
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: {},
+        order: { createdAt: 'DESC' },
+        relations: ['deliveries'],
+      });
+      expect(result).toEqual(webhooks);
+    });
+
+    it('should filter by userId when provided', async () => {
+      const webhooks = [{ id: 'webhook-1', userId: 'user-1' }];
+
+      mockRepository.find.mockResolvedValue(webhooks);
+
+      const result = await service.findAll('user-1');
+
+      expect(mockRepository.find).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        order: { createdAt: 'DESC' },
+        relations: ['deliveries'],
+      });
+      expect(result).toEqual(webhooks);
+    });
+  });
+
+  describe('findOne', () => {
+    it('should return a webhook by id', async () => {
+      const webhook = { id: 'webhook-123', userId: 'user-1' };
+
+      mockRepository.findOne.mockResolvedValue(webhook);
+
+      const result = await service.findOne('webhook-123');
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { id: 'webhook-123' },
+        relations: ['deliveries'],
+      });
+      expect(result).toEqual(webhook);
+    });
+
+    it('should throw NotFoundException if webhook not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.findOne('non-existent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+  });
+
+  describe('update', () => {
+    it('should update a webhook successfully', async () => {
+      const webhook = {
+        id: 'webhook-123',
+        userId: 'user-1',
+        url: 'https://example.com/webhook',
+        events: [WebhookEventType.SPLIT_CREATED],
+        secret: 'old-secret',
+        isActive: true,
+      };
+
+      const updateDto: UpdateWebhookDto = {
+        url: 'https://newurl.com/webhook',
+        isActive: false,
+      };
+
+      mockRepository.findOne.mockResolvedValue(webhook);
+      mockRepository.save.mockResolvedValue({ ...webhook, ...updateDto });
+
+      const result = await service.update('webhook-123', updateDto);
+
+      expect(mockRepository.findOne).toHaveBeenCalled();
+      expect(mockRepository.save).toHaveBeenCalled();
+      expect(result.url).toBe(updateDto.url);
+      expect(result.isActive).toBe(updateDto.isActive);
+    });
+  });
+
+  describe('remove', () => {
+    it('should delete a webhook', async () => {
+      const webhook = { id: 'webhook-123' };
+
+      mockRepository.findOne.mockResolvedValue(webhook);
+      mockRepository.remove.mockResolvedValue(webhook);
+
+      await service.remove('webhook-123');
+
+      expect(mockRepository.findOne).toHaveBeenCalled();
+      expect(mockRepository.remove).toHaveBeenCalledWith(webhook);
+    });
+  });
+
+  describe('incrementFailureCount', () => {
+    it('should increment failure count', async () => {
+      const webhook = {
+        id: 'webhook-123',
+        failureCount: 5,
+        isActive: true,
+      };
+
+      mockRepository.findOne.mockResolvedValue(webhook);
+      mockRepository.save.mockResolvedValue({
+        ...webhook,
+        failureCount: 6,
+      });
+
+      await service.incrementFailureCount('webhook-123');
+
+      expect(webhook.failureCount).toBe(6);
+    });
+
+    it('should deactivate webhook after 10 failures', async () => {
+      const webhook = {
+        id: 'webhook-123',
+        failureCount: 9,
+        isActive: true,
+      };
+
+      mockRepository.findOne.mockResolvedValue(webhook);
+      mockRepository.save.mockResolvedValue({
+        ...webhook,
+        failureCount: 10,
+        isActive: false,
+      });
+
+      await service.incrementFailureCount('webhook-123');
+
+      expect(webhook.failureCount).toBe(10);
+      expect(webhook.isActive).toBe(false);
+    });
+  });
+});

--- a/backend/src/webhooks/webhooks.service.ts
+++ b/backend/src/webhooks/webhooks.service.ts
@@ -1,0 +1,125 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Webhook, WebhookEventType } from './webhook.entity';
+import { CreateWebhookDto } from './dto/create-webhook.dto';
+import { UpdateWebhookDto } from './dto/update-webhook.dto';
+
+@Injectable()
+export class WebhooksService {
+  private readonly logger = new Logger(WebhooksService.name);
+
+  constructor(
+    @InjectRepository(Webhook)
+    private readonly webhookRepository: Repository<Webhook>,
+  ) {}
+
+  async create(createWebhookDto: CreateWebhookDto): Promise<Webhook> {
+    // Validate URL is reachable (basic check)
+    if (!this.isValidUrl(createWebhookDto.url)) {
+      throw new BadRequestException('Invalid webhook URL');
+    }
+
+    const webhook = this.webhookRepository.create({
+      ...createWebhookDto,
+      isActive: true,
+      failureCount: 0,
+    });
+
+    return await this.webhookRepository.save(webhook);
+  }
+
+  async findAll(userId?: string): Promise<Webhook[]> {
+    const where = userId ? { userId } : {};
+    return await this.webhookRepository.find({
+      where,
+      order: { createdAt: 'DESC' },
+      relations: ['deliveries'],
+    });
+  }
+
+  async findOne(id: string): Promise<Webhook> {
+    const webhook = await this.webhookRepository.findOne({
+      where: { id },
+      relations: ['deliveries'],
+    });
+
+    if (!webhook) {
+      throw new NotFoundException(`Webhook with ID ${id} not found`);
+    }
+
+    return webhook;
+  }
+
+  async findByUserId(userId: string): Promise<Webhook[]> {
+    return await this.webhookRepository.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async findByEventType(eventType: WebhookEventType): Promise<Webhook[]> {
+    return await this.webhookRepository
+      .createQueryBuilder('webhook')
+      .where('webhook.isActive = :isActive', { isActive: true })
+      .andWhere('webhook.events @> :event', {
+        event: JSON.stringify([eventType]),
+      })
+      .getMany();
+  }
+
+  async update(id: string, updateWebhookDto: UpdateWebhookDto): Promise<Webhook> {
+    const webhook = await this.findOne(id);
+
+    if (updateWebhookDto.url && !this.isValidUrl(updateWebhookDto.url)) {
+      throw new BadRequestException('Invalid webhook URL');
+    }
+
+    Object.assign(webhook, updateWebhookDto);
+    return await this.webhookRepository.save(webhook);
+  }
+
+  async remove(id: string): Promise<void> {
+    const webhook = await this.findOne(id);
+    await this.webhookRepository.remove(webhook);
+  }
+
+  async incrementFailureCount(id: string): Promise<void> {
+    const webhook = await this.findOne(id);
+    webhook.failureCount += 1;
+
+    // Deactivate if failure count exceeds threshold (e.g., 10 failures)
+    if (webhook.failureCount >= 10) {
+      webhook.isActive = false;
+      this.logger.warn(`Webhook ${id} deactivated due to excessive failures`);
+    }
+
+    await this.webhookRepository.save(webhook);
+  }
+
+  async resetFailureCount(id: string): Promise<void> {
+    const webhook = await this.findOne(id);
+    webhook.failureCount = 0;
+    await this.webhookRepository.save(webhook);
+  }
+
+  async updateLastTriggered(id: string): Promise<void> {
+    const webhook = await this.findOne(id);
+    webhook.lastTriggeredAt = new Date();
+    await this.webhookRepository.save(webhook);
+  }
+
+  private isValidUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url);
+      return ['http:', 'https:'].includes(parsed.protocol);
+    } catch {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
Webhook system has been fully implemented with CRUD support, event subscriptions, HMAC signing, retries, delivery logging, and rate limiting. All webhook-related unit tests are passing successfully.
<img width="1440" height="900" alt="Screen Shot 2026-01-30 at 12 58 23 PM" src="https://github.com/user-attachments/assets/847b1091-5eac-4b25-8cd3-6afb163ca25b" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Webhook management system with create, read, update, and delete operations
  * Webhook event subscription and testing capabilities
  * Delivery tracking with logs and statistics
  * Automatic retry mechanism with exponential backoff for failed webhook deliveries

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->