### PR TITLE
feat/Build Dispute Resolution Contract

### DIFF
--- a/contracts/dispute-resolution/Cargo.toml
+++ b/contracts/dispute-resolution/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "dispute-resolution"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/dispute-resolution/src/errors.rs
+++ b/contracts/dispute-resolution/src/errors.rs
@@ -1,0 +1,15 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Clone, Debug, PartialEq)]
+pub enum Error {
+    NotFound = 1,
+    AlreadyExists = 2,
+    NotAuthorized = 3,
+    AlreadyVoted = 4,
+    DisputeClosed = 5,
+    VotingPeriodActive = 6,
+    VotingPeriodEnded = 7,
+    InvalidReason = 8,
+    SplitNotFound = 9,
+}

--- a/contracts/dispute-resolution/src/lib.rs
+++ b/contracts/dispute-resolution/src/lib.rs
@@ -1,0 +1,164 @@
+#![no_std]
+
+mod errors;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+use soroban_sdk::{contract, contractimpl, Bytes, Env, String, Address};
+use errors::Error;
+use types::{DataKey, Dispute, DisputeResult, DisputeStatus};
+
+const VOTING_PERIOD: u64 = 604_800; // 7 days in seconds
+
+fn generate_dispute_id(env: &Env, split_id: &String) -> String {
+    let mut input = Bytes::new(env);
+    input.append(&split_id.to_bytes());
+    let seq = env.ledger().sequence().to_be_bytes();
+    input.append(&Bytes::from_slice(env, &seq));
+    let hash = env.crypto().sha256(&input);
+    let hash_bytes = &hash.to_array()[..8];
+    let mut id_bytes = String::from_str(env, "dis_").to_bytes();
+    id_bytes.append(&Bytes::from_slice(env, hash_bytes));
+    String::from_bytes(env, &id_bytes)
+}
+
+#[contract]
+pub struct DisputeContract;
+
+#[contractimpl]
+impl DisputeContract {
+
+    /// Raise a new dispute against a split.
+    pub fn raise_dispute(
+        env: Env,
+        split_id: String,
+        raiser: Address,
+        reason: String,
+    ) -> Result<String, Error> {
+        raiser.require_auth();
+
+        let now = env.ledger().timestamp();
+        let dispute_id = generate_dispute_id(&env, &split_id);
+
+        if storage::has_dispute(&env, &dispute_id) {
+            return Err(Error::AlreadyExists);
+        }
+
+        let dispute = Dispute {
+            dispute_id: dispute_id.clone(),
+            split_id,
+            raiser,
+            reason,
+            status: DisputeStatus::Voting,
+            votes_for: 0,
+            votes_against: 0,
+            voters: soroban_sdk::Vec::new(&env),
+            created_at: now,
+            voting_ends_at: now + VOTING_PERIOD,
+            result: None,
+        };
+
+        storage::save_dispute(&env, &dispute);
+        storage::add_to_list(&env, dispute_id.clone());
+
+        Ok(dispute_id)
+    }
+
+    /// Cast a vote on an open dispute.
+    pub fn vote_on_dispute(
+        env: Env,
+        dispute_id: String,
+        voter: Address,
+        support: bool, // true = support the dispute, false = dismiss it
+    ) -> Result<(), Error> {
+        voter.require_auth();
+
+        let mut dispute = storage::get_dispute(&env, &dispute_id)?;
+
+        // Must be in Voting status
+        if dispute.status != DisputeStatus::Voting {
+            return Err(Error::DisputeClosed);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Voting window must still be open
+        if now > dispute.voting_ends_at {
+            return Err(Error::VotingPeriodEnded);
+        }
+
+        // Each address can only vote once
+        if storage::has_voted(&env, &dispute_id, &voter) {
+            return Err(Error::AlreadyVoted);
+        }
+
+        // Record the vote
+        if support {
+            dispute.votes_for += 1;
+        } else {
+            dispute.votes_against += 1;
+        }
+
+        dispute.voters.push_back(voter.clone());
+        storage::record_vote(&env, &dispute_id, &voter);
+        storage::save_dispute(&env, &dispute);
+
+        Ok(())
+    }
+
+    /// Resolve a dispute after voting period ends.
+    pub fn resolve_dispute(
+        env: Env,
+        dispute_id: String,
+    ) -> Result<DisputeResult, Error> {
+        let mut dispute = storage::get_dispute(&env, &dispute_id)?;
+
+        if dispute.status != DisputeStatus::Voting {
+            return Err(Error::DisputeClosed);
+        }
+
+        let now = env.ledger().timestamp();
+
+        // Voting period must have ended
+        if now <= dispute.voting_ends_at {
+            return Err(Error::VotingPeriodActive);
+        }
+
+        // Determine result based on votes
+        let result = if dispute.votes_for > dispute.votes_against {
+            DisputeResult::UpheldForRaiser
+        } else if dispute.votes_against > dispute.votes_for {
+            DisputeResult::DismissedForRaiser
+        } else {
+            DisputeResult::Tied
+        };
+
+        dispute.status = DisputeStatus::Resolved;
+        dispute.result = Some(result.clone());
+
+        storage::save_dispute(&env, &dispute);
+
+        // TODO: trigger payout logic based on result
+        // if result == DisputeResult::UpheldForRaiser {
+        //     split_client.reverse_split(&dispute.split_id);
+        // }
+
+        Ok(result)
+    }
+
+    /// Get a dispute record.
+    pub fn get_dispute(
+        env: Env,
+        dispute_id: String,
+    ) -> Result<Dispute, Error> {
+        storage::get_dispute(&env, &dispute_id)
+    }
+
+    /// Get all dispute IDs.
+    pub fn get_all_disputes(env: Env) -> soroban_sdk::Vec<String> {
+        storage::get_list(&env)
+    }
+}

--- a/contracts/dispute-resolution/src/storage.rs
+++ b/contracts/dispute-resolution/src/storage.rs
@@ -1,0 +1,53 @@
+use soroban_sdk::{Env, String, Address, Vec};
+use crate::types::{DataKey, Dispute};
+use crate::errors::Error;
+
+pub fn save_dispute(env: &Env, dispute: &Dispute) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Dispute(dispute.dispute_id.clone()), dispute);
+}
+
+pub fn get_dispute(env: &Env, dispute_id: &String) -> Result<Dispute, Error> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Dispute(dispute_id.clone()))
+        .ok_or(Error::NotFound)
+}
+
+pub fn has_dispute(env: &Env, dispute_id: &String) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::Dispute(dispute_id.clone()))
+}
+
+pub fn add_to_list(env: &Env, dispute_id: String) {
+    let mut list: Vec<String> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::DisputeList)
+        .unwrap_or(Vec::new(env));
+    list.push_back(dispute_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::DisputeList, &list);
+}
+
+pub fn get_list(env: &Env) -> Vec<String> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::DisputeList)
+        .unwrap_or(Vec::new(env))
+}
+
+pub fn has_voted(env: &Env, dispute_id: &String, voter: &Address) -> bool {
+    env.storage()
+        .persistent()
+        .has(&DataKey::VoterRecord(dispute_id.clone(), voter.clone()))
+}
+
+pub fn record_vote(env: &Env, dispute_id: &String, voter: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::VoterRecord(dispute_id.clone(), voter.clone()), &true);
+}

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -1,0 +1,214 @@
+#[cfg(test)]
+use crate::{DisputeContract, DisputeContractClient};
+use crate::errors::Error;
+use crate::types::{DisputeResult, DisputeStatus};
+use soroban_sdk::{testutils::{Address as _, Ledger}, Env, String};
+
+fn setup() -> (Env, DisputeContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register_contract(None, DisputeContract);
+    let client = DisputeContractClient::new(&env, &contract_id);
+    (env, client)
+}
+
+#[test]
+fn test_raise_dispute() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_001"),
+        &raiser,
+        &String::from_str(&env, "Payment was incorrect"),
+    ).unwrap();
+
+    let dispute = client.get_dispute(&id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Voting);
+    assert_eq!(dispute.votes_for, 0);
+    assert_eq!(dispute.votes_against, 0);
+    assert_eq!(dispute.voting_ends_at, 1000 + 604_800);
+}
+
+#[test]
+fn test_vote_for_dispute() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_002"),
+        &raiser,
+        &String::from_str(&env, "Wrong amount"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter, &true).unwrap();
+
+    let dispute = client.get_dispute(&id).unwrap();
+    assert_eq!(dispute.votes_for, 1);
+    assert_eq!(dispute.votes_against, 0);
+}
+
+#[test]
+fn test_vote_against_dispute() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_003"),
+        &raiser,
+        &String::from_str(&env, "Unfair split"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter, &false).unwrap();
+
+    let dispute = client.get_dispute(&id).unwrap();
+    assert_eq!(dispute.votes_for, 0);
+    assert_eq!(dispute.votes_against, 1);
+}
+
+#[test]
+fn test_double_vote_fails() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_004"),
+        &raiser,
+        &String::from_str(&env, "Duplicate payment"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter, &true).unwrap();
+    assert_eq!(
+        client.vote_on_dispute(&id, &voter, &true),
+        Err(Error::AlreadyVoted)
+    );
+}
+
+#[test]
+fn test_resolve_upheld() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter1 = soroban_sdk::Address::generate(&env);
+    let voter2 = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_005"),
+        &raiser,
+        &String::from_str(&env, "Missing funds"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter1, &true).unwrap();
+    client.vote_on_dispute(&id, &voter2, &true).unwrap();
+
+    // Advance past voting period
+    env.ledger().with_mut(|l| l.timestamp = 1000 + 604_801);
+
+    let result = client.resolve_dispute(&id).unwrap();
+    assert_eq!(result, DisputeResult::UpheldForRaiser);
+
+    let dispute = client.get_dispute(&id).unwrap();
+    assert_eq!(dispute.status, DisputeStatus::Resolved);
+}
+
+#[test]
+fn test_resolve_dismissed() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter1 = soroban_sdk::Address::generate(&env);
+    let voter2 = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_006"),
+        &raiser,
+        &String::from_str(&env, "Wrong recipient"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter1, &false).unwrap();
+    client.vote_on_dispute(&id, &voter2, &false).unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp = 1000 + 604_801);
+
+    let result = client.resolve_dispute(&id).unwrap();
+    assert_eq!(result, DisputeResult::DismissedForRaiser);
+}
+
+#[test]
+fn test_resolve_tied() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter1 = soroban_sdk::Address::generate(&env);
+    let voter2 = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_007"),
+        &raiser,
+        &String::from_str(&env, "Unclear terms"),
+    ).unwrap();
+
+    client.vote_on_dispute(&id, &voter1, &true).unwrap();
+    client.vote_on_dispute(&id, &voter2, &false).unwrap();
+
+    env.ledger().with_mut(|l| l.timestamp = 1000 + 604_801);
+
+    let result = client.resolve_dispute(&id).unwrap();
+    assert_eq!(result, DisputeResult::Tied);
+}
+
+#[test]
+fn test_resolve_before_voting_ends_fails() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_008"),
+        &raiser,
+        &String::from_str(&env, "Too early"),
+    ).unwrap();
+
+    // Try to resolve immediately
+    assert_eq!(
+        client.resolve_dispute(&id),
+        Err(Error::VotingPeriodActive)
+    );
+}
+
+#[test]
+fn test_vote_after_period_fails() {
+    let (env, client) = setup();
+    env.ledger().with_mut(|l| l.timestamp = 1000);
+
+    let raiser = soroban_sdk::Address::generate(&env);
+    let voter = soroban_sdk::Address::generate(&env);
+
+    let id = client.raise_dispute(
+        &String::from_str(&env, "split_009"),
+        &raiser,
+        &String::from_str(&env, "Late vote"),
+    ).unwrap();
+
+    // Advance past voting period then try to vote
+    env.ledger().with_mut(|l| l.timestamp = 1000 + 604_801);
+
+    assert_eq!(
+        client.vote_on_dispute(&id, &voter, &true),
+        Err(Error::VotingPeriodEnded)
+    );
+}

--- a/contracts/dispute-resolution/src/types.rs
+++ b/contracts/dispute-resolution/src/types.rs
@@ -1,0 +1,41 @@
+use soroban_sdk::{contracttype, String, Address, Vec};
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DisputeStatus {
+    Open,
+    Voting,
+    Resolved,
+    Cancelled,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub enum DisputeResult {
+    UpheldForRaiser,    // Dispute was valid, raiser wins
+    DismissedForRaiser, // Dispute was invalid, original split stands
+    Tied,               // Equal votes, default to original split
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Dispute {
+    pub dispute_id: String,
+    pub split_id: String,
+    pub raiser: Address,
+    pub reason: String,
+    pub status: DisputeStatus,
+    pub votes_for: u32,      // votes supporting the dispute
+    pub votes_against: u32,  // votes dismissing the dispute
+    pub voters: Vec<Address>,
+    pub created_at: u64,
+    pub voting_ends_at: u64, // voting window: 7 days
+    pub result: Option<DisputeResult>,
+}
+
+#[contracttype]
+pub enum DataKey {
+    Dispute(String),
+    DisputeList,
+    VoterRecord(String, Address), // (dispute_id, voter) -> bool (has voted)
+}


### PR DESCRIPTION
PR 1: Recurring Payment Contract

Implements the recurring split payment contract on Soroban. Adds create_recurring to schedule automated payments by frequency (daily/weekly/monthly) with an optional end date, process_recurring for permissionless execution by a keeper bot, and cancel_recurring restricted to the original creator. Includes storage helpers, type definitions, and comprehensive tests covering due dates, expiry, cancellation, and auth checks.


PR 2: Dispute Resolution Contract

Implements the on-chain dispute resolution contract on Soroban. Adds raise_dispute to open a dispute against a split, vote_on_dispute for community voting with one-vote-per-address enforcement, and resolve_dispute to automatically determine the outcome after a 7-day voting window. Results are calculated by majority vote with a tie defaulting to the original split. Includes storage helpers, type definitions, and comprehensive tests covering voting, double-vote prevention, early resolution attempts, and all three outcome states.

Closes #107 
Closes #108 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Introduced a dispute resolution system enabling users to raise disputes tied to splits.
* Added voting capabilities during a 7-day voting window with one-vote-per-participant enforcement.
* Implemented automated dispute resolution based on vote tallies (upheld, dismissed, or tied outcomes).
* Provided query methods to retrieve individual dispute details and view all disputes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->