### PR TITLE
feat(short-links): implement expiring deep links with NFC + SEP-0007 …

### DIFF
--- a/backend/src/short-links/ nfc-payload.service.ts
+++ b/backend/src/short-links/ nfc-payload.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class NfcPayloadService {
+  generateNdefPayload(url: string) {
+    const uriRecord = Buffer.from(url, 'utf8');
+
+    return {
+      ndefMessage: {
+        tnf: 1,
+        type: 'U',
+        payload: uriRecord.toString('hex'),
+      },
+    };
+  }
+}

--- a/backend/src/short-links/dto/generate-link.dto.ts
+++ b/backend/src/short-links/dto/generate-link.dto.ts
@@ -1,0 +1,19 @@
+import { IsEnum, IsOptional, IsUUID, IsNumber, Min } from 'class-validator';
+import { LinkType } from '../entities/split-short-link.entity';
+
+export class GenerateLinkDto {
+  @IsUUID()
+  splitId: string;
+
+  @IsEnum(LinkType)
+  linkType: LinkType;
+
+  @IsOptional()
+  @IsUUID()
+  targetParticipantId?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  expiryHours?: number;
+}

--- a/backend/src/short-links/entities/link-access-log.entity.ts
+++ b/backend/src/short-links/entities/link-access-log.entity.ts
@@ -1,0 +1,29 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+} from 'typeorm';
+import { SplitShortLink } from './split-short-link.entity';
+
+@Entity('link_access_logs')
+export class LinkAccessLog {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => SplitShortLink, { onDelete: 'CASCADE' })
+  shortLink: SplitShortLink;
+
+  @CreateDateColumn()
+  accessedAt: Date;
+
+  @Column()
+  ipHash: string;
+
+  @Column()
+  userAgent: string;
+
+  @Column({ nullable: true })
+  resolvedUserId?: string;
+}

--- a/backend/src/short-links/entities/split-short-link.entity.ts
+++ b/backend/src/short-links/entities/split-short-link.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { Split } from '../../splits/entities/split.entity';
+import { Participant } from '../../participants/entities/participant.entity';
+
+export enum LinkType {
+  VIEW_SPLIT = 'view_split',
+  JOIN_SPLIT = 'join_split',
+  PAY_SHARE = 'pay_share',
+  NFC_TAP = 'nfc_tap',
+}
+
+@Entity('split_short_links')
+export class SplitShortLink {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Split, { onDelete: 'CASCADE' })
+  split: Split;
+
+  @Index({ unique: true })
+  @Column({ length: 6 })
+  shortCode: string;
+
+  @Column({ type: 'enum', enum: LinkType })
+  linkType: LinkType;
+
+  @ManyToOne(() => Participant, { nullable: true })
+  targetParticipant?: Participant;
+
+  @Column({ default: 0 })
+  accessCount: number;
+
+  @Column({ nullable: true })
+  maxAccesses?: number;
+
+  @Column()
+  expiresAt: Date;
+
+  @Column()
+  createdBy: string; // wallet address
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/backend/src/short-links/short-links.controller.ts
+++ b/backend/src/short-links/short-links.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Delete,
+  Param,
+  Body,
+  Req,
+} from '@nestjs/common';
+import { ShortLinksService } from './short-links.service';
+import { NfcPayloadService } from './nfc-payload.service';
+import { GenerateLinkDto } from './dto/generate-link.dto';
+
+@Controller('api/short-links')
+export class ShortLinksController {
+  constructor(
+    private readonly service: ShortLinksService,
+    private readonly nfcService: NfcPayloadService,
+  ) {}
+
+  @Post('generate')
+  generate(@Body() dto: GenerateLinkDto, @Req() req) {
+    return this.service.generate(dto, req.user.wallet);
+  }
+
+  @Get(':shortCode/resolve')
+  resolve(@Param('shortCode') code: string, @Req() req) {
+    return this.service.resolve(
+      code,
+      req.ip,
+      req.headers['user-agent'],
+      req.user?.id,
+    );
+  }
+
+  @Get(':shortCode/analytics')
+  analytics(@Param('shortCode') code: string) {
+    return this.service.analytics(code);
+  }
+
+  @Post('nfc-payload/:splitId')
+  generateNfc(@Param('splitId') splitId: string) {
+    const url = `${process.env.FRONTEND_URL}/splits/${splitId}`;
+    return this.nfcService.generateNdefPayload(url);
+  }
+
+  @Delete(':shortCode')
+  delete(@Param('shortCode') code: string) {
+    return this.service.delete(code);
+  }
+}

--- a/backend/src/short-links/short-links.module.ts
+++ b/backend/src/short-links/short-links.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SplitShortLink } from './entities/split-short-link.entity';
+import { LinkAccessLog } from './entities/link-access-log.entity';
+import { ShortLinksService } from './short-links.service';
+import { ShortLinksController } from './short-links.controller';
+import { NfcPayloadService } from './nfc-payload.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SplitShortLink, LinkAccessLog])],
+  providers: [ShortLinksService, NfcPayloadService],
+  controllers: [ShortLinksController],
+})
+export class ShortLinksModule {}

--- a/backend/src/short-links/short-links.service.ts
+++ b/backend/src/short-links/short-links.service.ts
@@ -1,0 +1,131 @@
+import {
+  Injectable,
+  BadRequestException,
+  NotFoundException,
+  ForbiddenException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { SplitShortLink, LinkType } from './entities/split-short-link.entity';
+import { LinkAccessLog } from './entities/link-access-log.entity';
+import { GenerateLinkDto } from './dto/generate-link.dto';
+import * as crypto from 'crypto';
+
+@Injectable()
+export class ShortLinksService {
+  constructor(
+    @InjectRepository(SplitShortLink)
+    private shortLinkRepo: Repository<SplitShortLink>,
+
+    @InjectRepository(LinkAccessLog)
+    private accessLogRepo: Repository<LinkAccessLog>,
+  ) {}
+
+  // 🔹 Generate 6-char unique short code
+  private async generateUniqueCode(): Promise<string> {
+    let code: string;
+    let exists = true;
+
+    while (exists) {
+      code = crypto.randomBytes(4).toString('base64url').slice(0, 6);
+      const found = await this.shortLinkRepo.findOne({ where: { shortCode: code } });
+      exists = !!found;
+    }
+
+    return code;
+  }
+
+  // 🔹 Generate link
+  async generate(dto: GenerateLinkDto, wallet: string) {
+    // Rate limit: 20 per split per user
+    const count = await this.shortLinkRepo.count({
+      where: {
+        split: { id: dto.splitId },
+        createdBy: wallet,
+      },
+    });
+
+    if (count >= 20) {
+      throw new ForbiddenException('Link generation limit reached');
+    }
+
+    const shortCode = await this.generateUniqueCode();
+
+    const expiry =
+      dto.expiryHours
+        ? new Date(Date.now() + dto.expiryHours * 3600000)
+        : new Date(Date.now() + 72 * 3600000); // 72 hours default
+
+    const link = this.shortLinkRepo.create({
+      split: { id: dto.splitId } as any,
+      shortCode,
+      linkType: dto.linkType,
+      targetParticipant: dto.targetParticipantId
+        ? ({ id: dto.targetParticipantId } as any)
+        : null,
+      expiresAt: expiry,
+      createdBy: wallet,
+    });
+
+    await this.shortLinkRepo.save(link);
+
+    const sepUri = this.buildSep0007Uri(dto.splitId);
+
+    return {
+      shortCode,
+      url: `${process.env.FRONTEND_URL}/l/${shortCode}`,
+      sep0007: sepUri,
+      expiresAt: expiry,
+    };
+  }
+
+  // 🔹 Resolve link
+  async resolve(shortCode: string, ip: string, userAgent: string, userId?: string) {
+    const link = await this.shortLinkRepo.findOne({
+      where: { shortCode },
+      relations: ['split'],
+    });
+
+    if (!link) throw new NotFoundException('Link not found');
+
+    if (link.expiresAt < new Date()) {
+      throw new BadRequestException('Link expired');
+    }
+
+    if (link.maxAccesses && link.accessCount >= link.maxAccesses) {
+      throw new ForbiddenException('Max access reached');
+    }
+
+    link.accessCount++;
+    await this.shortLinkRepo.save(link);
+
+    await this.accessLogRepo.save({
+      shortLink: link,
+      ipHash: crypto.createHash('sha256').update(ip).digest('hex'),
+      userAgent,
+      resolvedUserId: userId,
+    });
+
+    return {
+      redirectUrl: `${process.env.FRONTEND_URL}/splits/${link.split.id}`,
+      linkType: link.linkType,
+    };
+  }
+
+  // 🔹 SEP-0007 URI
+  private buildSep0007Uri(splitId: string) {
+    return `web+stellar:pay?destination=${process.env.PLATFORM_WALLET}&memo=${splitId}`;
+  }
+
+  async analytics(shortCode: string) {
+    const logs = await this.accessLogRepo.find({
+      where: { shortLink: { shortCode } },
+    });
+
+    return {
+      totalAccess: logs.length,
+      uniqueIPs: new Set(logs.map(l => l.ipHash)).size,
+      lastAccess: logs.sort((a, b) => b.accessedAt.getTime() - a.accessedAt.getTime())[0],
+    };
+  }
+}


### PR DESCRIPTION
- Added SplitShortLink and LinkAccessLog entities
- Implemented short link generation with 6-char unique URL-safe codes
- Enforced 72-hour default expiration (configurable)
- Added rate limiting (20 links per split per wallet)
- Implemented link resolution with access logging and IP hashing
- Embedded SEP-0007 Stellar payment URI in generated links
- Added NFC NDEF payload generator for mobile tap payments
- Implemented analytics endpoint for link access tracking
- Added validation DTO and module wiring
- Generated database migration for short links system

closes #151 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added short link generation with rate limiting (max 20 per split per user) and configurable expiry.
  * Implemented link resolution with automatic access tracking and analytics (total accesses, unique IPs, last access).
  * Added support for multiple link types: view split, join split, pay share, and NFC tap.
  * Introduced NFC payload generation for QR code sharing.
  * Added link deletion capability and max access limits per link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->