### PR TITLE
 i implement the Store metadata in escrow record

### DIFF
--- a/contract/split-escrow/Cargo.toml
+++ b/contract/split-escrow/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "split-escrow"
+version = "0.1.0"
+authors = ["Your Name <youremail@example.com>"]
+edition = "2021"
+description = "Soroban contract for escrow with optional on-chain metadata"
+license = "MIT"
+
+# This tells Cargo it’s a library crate (needed for Soroban contracts)
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+soroban-sdk = { version = "0.23.0", features = ["testutils"] }
+
+[profile.release]
+# Optimize for WebAssembly (Soroban target)
+opt-level = "z"
+lto = true
+panic = "abort"
+codegen-units = 1

--- a/contract/split-escrow/Unit Tests lib.rs/Unit Tests lib.rs
+++ b/contract/split-escrow/Unit Tests lib.rs/Unit Tests lib.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod test {
+    use super::*;
+    use soroban_sdk::testutils::Env;
+
+    #[test]
+    fn test_metadata_lifecycle() {
+        let env = Env::default();
+        let creator = Address::random(&env);
+
+        // Create escrow with metadata
+        let mut escrow = create_escrow(
+            env.clone(),
+            creator.clone(),
+            100,
+            Some(Map::from_vec(&env, vec![("title".to_string(), "MyEscrow".to_string())]))
+        );
+
+        // Check get_metadata
+        let meta = get_metadata(env.clone(), &escrow).unwrap();
+        assert_eq!(meta.get("title").unwrap(), "MyEscrow");
+
+        // Update metadata
+        let updates = Map::from_vec(&env, vec![("title".to_string(), "Updated".to_string())]);
+        update_metadata(env.clone(), &mut escrow, creator.clone(), updates).unwrap();
+
+        let updated_meta = get_metadata(env.clone(), &escrow).unwrap();
+        assert_eq!(updated_meta.get("title").unwrap(), "Updated");
+
+        // Fail if non-creator tries to update
+        let other = Address::random(&env);
+        let updates2 = Map::from_vec(&env, vec![("title".to_string(), "Hacker".to_string())]);
+        assert!(update_metadata(env.clone(), &mut escrow, other, updates2).is_err());
+    }
+}

--- a/contract/split-escrow/src/lib.rs
+++ b/contract/split-escrow/src/lib.rs
@@ -1,0 +1,60 @@
+use crate::types::Metadata;
+
+#[contracttype]
+pub struct Escrow {
+    pub creator: Address,
+    pub amount: i128,
+    pub active: bool,
+    pub metadata: Option<Metadata>, // NEW
+}
+
+Update create_escrow()
+    pub fn create_escrow(env: Env, creator: Address, amount: i128, metadata: Option<Map<String, String>>) -> Escrow {
+    let mut md = metadata.map(|m| {
+        let mut meta = Metadata::new(&env);
+        for (k, v) in m.iter() {
+            meta.insert(k.clone(), v.clone()).expect("Metadata insert failed");
+        }
+        meta
+    });
+
+    Escrow {
+        creator,
+        amount,
+        active: true,
+        metadata: md,
+    }
+}
+get_metadata()
+pub fn get_metadata(env: Env, escrow: &Escrow) -> Option<Map<String, String>> {
+    escrow.metadata.as_ref().map(|md| {
+        let mut result = Map::new(&env);
+        for (k, v) in md.data.iter() {
+            result.insert(k.to_string(), v.to_string());
+        }
+        result
+    })
+}
+update_metadata()
+pub fn update_metadata(env: Env, escrow: &mut Escrow, caller: Address, updates: Map<String, String>) -> Result<(), &'static str> {
+    if caller != escrow.creator {
+        return Err("Only creator can update metadata");
+    }
+    if !escrow.active {
+        return Err("Escrow not active");
+    }
+
+    if let Some(ref mut md) = escrow.metadata {
+        for (k, v) in updates.iter() {
+            md.update(k.to_string(), v.to_string())?;
+        }
+    } else {
+        let mut md = Metadata::new(&env);
+        for (k, v) in updates.iter() {
+            md.insert(k.to_string(), v.to_string())?;
+        }
+        escrow.metadata = Some(md);
+    }
+
+    Ok(())
+}

--- a/contract/split-escrow/src/types.rs
+++ b/contract/split-escrow/src/types.rs
@@ -1,0 +1,42 @@
+use soroban_sdk::{contracttype, symbol, Env};
+use soroban_sdk::vec::Vec;
+use soroban_sdk::map::Map;
+
+pub const MAX_KEYS: usize = 5;
+pub const MAX_KEY_LEN: usize = 64;
+pub const MAX_VALUE_LEN: usize = 64;
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Metadata {
+    pub data: Map<symbol!(String), symbol!(String)>,
+}
+
+impl Metadata {
+    pub fn new(env: &Env) -> Self {
+        Self { data: Map::new(env) }
+    }
+
+    pub fn insert(&mut self, key: String, value: String) -> Result<(), &'static str> {
+        if self.data.len() >= MAX_KEYS {
+            return Err("Metadata max keys reached");
+        }
+        if key.len() > MAX_KEY_LEN || value.len() > MAX_VALUE_LEN {
+            return Err("Key or value length exceeded");
+        }
+        self.data.insert(symbol!(key), symbol!(value));
+        Ok(())
+    }
+
+    pub fn update(&mut self, key: String, value: String) -> Result<(), &'static str> {
+        if !self.data.contains_key(&symbol!(key)) {
+            return Err("Key does not exist");
+        }
+        if value.len() > MAX_VALUE_LEN {
+            return Err("Value length exceeded");
+        }
+        self.data.insert(symbol!(key), symbol!(value));
+        Ok(())
+    }
+    
+}


### PR DESCRIPTION
feat: store optional metadata on-chain for escrow

- Allow escrows to include optional metadata (title, description, category) on creation
- Added `Metadata` struct with max 5 key/value pairs, 64 chars each
- Implemented `get_metadata()` to fetch metadata
- Implemented `update_metadata()` for creator while escrow is Active
- Added validation for key/value limits and creator-only updates
- Included unit tests for create, read, update, and access control

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a split-escrow contract crate with metadata support.
  * Escrow creator can create, retrieve, and update metadata with key-value pairs.
  * Metadata enforces size constraints: maximum 5 pairs with 64-character limits.
  * Creator-only authorization for metadata updates.

* **Tests**
  * Added comprehensive unit tests for metadata CRUD operations and access control validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->