### PR TITLE
implement debt simplification module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -43,6 +43,7 @@ import { UploadModule } from "./uploads/upload.module";
 import { ProfileModule } from "./profile/profile.module";
 import { InvitationsModule } from "./invitations/invitations.module";
 import { CommonModule } from "./common/common.module";
+import { DebtSimplificationModule } from "./debt-simplification/debt-simplification.module";
 // Load environment variables
 dotenv.config({
   path: path.resolve(__dirname, '../.env'),
@@ -124,6 +125,7 @@ dotenv.config({
     ProfileModule,
     InvitationsModule,
     CommonModule,
+    DebtSimplificationModule,
   ],
 })
 export class AppModule { }

--- a/backend/src/debt-simplification/debt-graph.service.spec.ts
+++ b/backend/src/debt-simplification/debt-graph.service.spec.ts
@@ -1,0 +1,184 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { DebtGraphService, RawDebt } from './debt-graph.service';
+import { Participant } from '../entities/participant.entity';
+import { Split } from '../entities/split.entity';
+
+/** Build a minimal mock repository */
+const mockRepo = () => ({
+  createQueryBuilder: jest.fn(),
+  findOne: jest.fn(),
+  find: jest.fn(),
+  save: jest.fn(),
+  delete: jest.fn(),
+});
+
+describe('DebtGraphService – simplify()', () => {
+  let service: DebtGraphService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DebtGraphService,
+        { provide: getRepositoryToken(Participant), useFactory: mockRepo },
+        { provide: getRepositoryToken(Split), useFactory: mockRepo },
+      ],
+    }).compile();
+
+    service = module.get<DebtGraphService>(DebtGraphService);
+  });
+
+  // ─── Empty input ─────────────────────────────────────────────────────────────
+  it('returns empty result for no debts', () => {
+    const result = service.simplify([]);
+    expect(result.simplifiedDebts).toHaveLength(0);
+    expect(result.originalTransactionCount).toBe(0);
+    expect(result.simplifiedTransactionCount).toBe(0);
+    expect(result.savingsPercentage).toBe(0);
+  });
+
+  // ─── Single debt ─────────────────────────────────────────────────────────────
+  it('keeps single debt unchanged', () => {
+    const raw: RawDebt[] = [{ from: 'A', to: 'B', amount: 10, asset: 'XLM' }];
+    const result = service.simplify(raw);
+    expect(result.simplifiedDebts).toHaveLength(1);
+    expect(result.simplifiedDebts[0]).toMatchObject({ from: 'A', to: 'B', amount: 10, asset: 'XLM' });
+    expect(result.savingsPercentage).toBe(0);
+  });
+
+  // ─── Triangle (A→B, B→C, A→C) can become at most 2 payments ─────────────────
+  it('simplifies a triangle of 3 debts into 2 transactions', () => {
+    const raw: RawDebt[] = [
+      { from: 'A', to: 'B', amount: 10, asset: 'XLM' },
+      { from: 'B', to: 'C', amount: 10, asset: 'XLM' },
+      { from: 'A', to: 'C', amount: 10, asset: 'XLM' },
+    ];
+    const result = service.simplify(raw);
+    // Net: A = -20, B = 0, C = +20 → only 1 transaction needed
+    expect(result.simplifiedTransactionCount).toBeLessThanOrEqual(2);
+    expect(result.originalTransactionCount).toBe(3);
+    assertNetBalancesPreserved(raw, result.simplifiedDebts, 'XLM');
+  });
+
+  // ─── Classic 4-person example (6 debts → ≤3) ────────────────────────────────
+  it('reduces 6 transactions (4 people) to ≤3', () => {
+    // A owes B 10, A owes C 15, B owes C 5, B owes D 10, C owes D 20, A owes D 5
+    const raw: RawDebt[] = [
+      { from: 'A', to: 'B', amount: 10, asset: 'XLM' },
+      { from: 'A', to: 'C', amount: 15, asset: 'XLM' },
+      { from: 'B', to: 'C', amount: 5, asset: 'XLM' },
+      { from: 'B', to: 'D', amount: 10, asset: 'XLM' },
+      { from: 'C', to: 'D', amount: 20, asset: 'XLM' },
+      { from: 'A', to: 'D', amount: 5, asset: 'XLM' },
+    ];
+    const result = service.simplify(raw);
+    expect(result.originalTransactionCount).toBe(6);
+    expect(result.simplifiedTransactionCount).toBeLessThanOrEqual(3); // N-1 = 3
+    assertNetBalancesPreserved(raw, result.simplifiedDebts, 'XLM');
+    expect(result.savingsPercentage).toBeGreaterThan(0);
+  });
+
+  // ─── Multi-currency: separate graphs per asset ───────────────────────────────
+  it('handles multi-currency debts in separate graphs', () => {
+    const raw: RawDebt[] = [
+      { from: 'A', to: 'B', amount: 10, asset: 'XLM' },
+      { from: 'B', to: 'C', amount: 10, asset: 'XLM' },
+      { from: 'A', to: 'B', amount: 50, asset: 'USDC:ISSUER' },
+      { from: 'B', to: 'C', amount: 50, asset: 'USDC:ISSUER' },
+    ];
+    const result = service.simplify(raw);
+
+    const xlmDebts = result.simplifiedDebts.filter((d) => d.asset === 'XLM');
+    const usdcDebts = result.simplifiedDebts.filter((d) => d.asset === 'USDC:ISSUER');
+
+    // Each currency is independently simplified
+    assertNetBalancesPreserved(
+      raw.filter((d) => d.asset === 'XLM'),
+      xlmDebts,
+      'XLM',
+    );
+    assertNetBalancesPreserved(
+      raw.filter((d) => d.asset === 'USDC:ISSUER'),
+      usdcDebts,
+      'USDC:ISSUER',
+    );
+  });
+
+  // ─── 20-user performance test ────────────────────────────────────────────────
+  it('simplifies 20 users with dense debts in under 100ms', () => {
+    const users = Array.from({ length: 20 }, (_, i) => `wallet${i}`);
+    const raw: RawDebt[] = [];
+
+    // Create a dense debt graph: every user owes the next one
+    for (let i = 0; i < users.length - 1; i++) {
+      for (let j = i + 1; j < users.length; j++) {
+        raw.push({
+          from: users[i],
+          to: users[j],
+          amount: Math.round(Math.random() * 100 * 100) / 100,
+          asset: 'XLM',
+        });
+      }
+    }
+
+    const start = Date.now();
+    const result = service.simplify(raw);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeLessThan(100);
+    expect(result.simplifiedTransactionCount).toBeLessThanOrEqual(users.length - 1);
+    assertNetBalancesPreserved(raw, result.simplifiedDebts, 'XLM');
+  });
+
+  // ─── Circular debts net to zero ──────────────────────────────────────────────
+  it('resolves circular debts to zero transactions when net is zero', () => {
+    // A→B 10, B→C 10, C→A 10 — net for all is 0
+    const raw: RawDebt[] = [
+      { from: 'A', to: 'B', amount: 10, asset: 'XLM' },
+      { from: 'B', to: 'C', amount: 10, asset: 'XLM' },
+      { from: 'C', to: 'A', amount: 10, asset: 'XLM' },
+    ];
+    const result = service.simplify(raw);
+    expect(result.simplifiedTransactionCount).toBe(0);
+    expect(result.savingsPercentage).toBe(100);
+  });
+
+  // ─── Known input → known output ──────────────────────────────────────────────
+  it('correctly simplifies known input: A owes B 30 → A pays B 30', () => {
+    const raw: RawDebt[] = [
+      { from: 'A', to: 'B', amount: 20, asset: 'XLM' },
+      { from: 'A', to: 'B', amount: 10, asset: 'XLM' },
+    ];
+    const result = service.simplify(raw);
+    // Net: A = -30, B = +30 → 1 transaction
+    expect(result.simplifiedTransactionCount).toBe(1);
+    expect(result.simplifiedDebts[0].from).toBe('A');
+    expect(result.simplifiedDebts[0].to).toBe('B');
+    expect(result.simplifiedDebts[0].amount).toBeCloseTo(30, 4);
+  });
+});
+
+// ─── Helper: verify net balances are preserved ────────────────────────────────
+function assertNetBalancesPreserved(
+  rawDebts: RawDebt[],
+  simplified: Array<{ from: string; to: string; amount: number; asset: string }>,
+  asset: string,
+): void {
+  const rawNet = new Map<string, number>();
+  for (const d of rawDebts.filter((r) => r.asset === asset)) {
+    rawNet.set(d.from, (rawNet.get(d.from) ?? 0) - d.amount);
+    rawNet.set(d.to, (rawNet.get(d.to) ?? 0) + d.amount);
+  }
+
+  const simNet = new Map<string, number>();
+  for (const d of simplified.filter((r) => r.asset === asset)) {
+    simNet.set(d.from, (simNet.get(d.from) ?? 0) - d.amount);
+    simNet.set(d.to, (simNet.get(d.to) ?? 0) + d.amount);
+  }
+
+  for (const [wallet, net] of rawNet.entries()) {
+    const simBalance = simNet.get(wallet) ?? 0;
+    expect(simBalance).toBeCloseTo(net, 4);
+  }
+}

--- a/backend/src/debt-simplification/debt-graph.service.ts
+++ b/backend/src/debt-simplification/debt-graph.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Participant } from '../entities/participant.entity';
+import { Split } from '../entities/split.entity';
+import { SimplifiedDebtEdge } from './entities/simplified-debt.entity';
+
+export interface RawDebt {
+  from: string;   // debtor wallet address
+  to: string;     // creditor wallet address
+  amount: number;
+  asset: string;
+}
+
+export interface DebtGraphResult {
+  simplifiedDebts: SimplifiedDebtEdge[];
+  originalTransactionCount: number;
+  simplifiedTransactionCount: number;
+  savingsPercentage: number;
+}
+
+@Injectable()
+export class DebtGraphService {
+  private readonly logger = new Logger(DebtGraphService.name);
+
+  constructor(
+    @InjectRepository(Participant)
+    private readonly participantRepo: Repository<Participant>,
+    @InjectRepository(Split)
+    private readonly splitRepo: Repository<Split>,
+  ) {}
+
+  /**
+   * Load raw outstanding debts for a set of wallet addresses across all their active splits.
+   * A participant "owes" (amountOwed - amountPaid) to the split creator.
+   */
+  async loadRawDebts(walletAddresses: string[], groupId?: string): Promise<RawDebt[]> {
+    // Build the query: find all non-fully-paid participants whose wallet is in the list
+    const qb = this.participantRepo
+      .createQueryBuilder('p')
+      .innerJoinAndSelect('p.split', 'split')
+      .where('p.walletAddress IN (:...wallets)', { wallets: walletAddresses })
+      .andWhere("p.status != 'paid'")
+      .andWhere('split.status != :completed', { completed: 'completed' })
+      .andWhere('split.isFrozen = false')
+      .andWhere('p.deleted_at IS NULL')
+      .andWhere('split.deleted_at IS NULL');
+
+    const participants = await qb.getMany();
+
+    const rawDebts: RawDebt[] = [];
+
+    for (const participant of participants) {
+      const split = participant.split!;
+      const balance = Number(participant.amountOwed) - Number(participant.amountPaid);
+      if (balance <= 0.0001) continue; // already settled (epsilon guard)
+
+      const creatorWallet = split.creatorWalletAddress;
+      if (!creatorWallet) continue;
+      if (!walletAddresses.includes(creatorWallet)) continue; // creator not in the requested set
+
+      const asset = split.preferredCurrency ?? 'XLM';
+
+      rawDebts.push({
+        from: participant.walletAddress!,
+        to: creatorWallet,
+        amount: balance,
+        asset,
+      });
+    }
+
+    return rawDebts;
+  }
+
+  /**
+   * Core greedy debt simplification algorithm.
+   *
+   * Strategy:
+   *  1. Separate debts by asset (currency).
+   *  2. For each asset, compute net balance per participant.
+   *  3. Apply the min-cash-flow greedy: repeatedly match the largest creditor
+   *     against the largest debtor until all balances are zero.
+   *
+   * This yields at most (N-1) transactions for N participants per asset,
+   * which is the theoretical minimum for a connected graph.
+   */
+  simplify(rawDebts: RawDebt[]): DebtGraphResult {
+    const originalTransactionCount = rawDebts.length;
+
+    if (rawDebts.length === 0) {
+      return {
+        simplifiedDebts: [],
+        originalTransactionCount: 0,
+        simplifiedTransactionCount: 0,
+        savingsPercentage: 0,
+      };
+    }
+
+    // Group raw debts by asset
+    const byAsset = new Map<string, RawDebt[]>();
+    for (const debt of rawDebts) {
+      const list = byAsset.get(debt.asset) ?? [];
+      list.push(debt);
+      byAsset.set(debt.asset, list);
+    }
+
+    const simplifiedDebts: SimplifiedDebtEdge[] = [];
+
+    for (const [asset, debts] of byAsset.entries()) {
+      const assetDebts = this.simplifyAsset(asset, debts);
+      simplifiedDebts.push(...assetDebts);
+    }
+
+    const simplifiedTransactionCount = simplifiedDebts.length;
+    const savingsPercentage =
+      originalTransactionCount > 0
+        ? Math.max(
+            0,
+            ((originalTransactionCount - simplifiedTransactionCount) /
+              originalTransactionCount) *
+              100,
+          )
+        : 0;
+
+    return {
+      simplifiedDebts,
+      originalTransactionCount,
+      simplifiedTransactionCount,
+      savingsPercentage: Math.round(savingsPercentage * 100) / 100,
+    };
+  }
+
+  /**
+   * Simplify debts for a single asset using the min-cash-flow greedy algorithm.
+   */
+  private simplifyAsset(asset: string, debts: RawDebt[]): SimplifiedDebtEdge[] {
+    // Compute net balance per wallet (positive = creditor, negative = debtor)
+    const balance = new Map<string, number>();
+
+    for (const debt of debts) {
+      balance.set(debt.from, (balance.get(debt.from) ?? 0) - debt.amount);
+      balance.set(debt.to, (balance.get(debt.to) ?? 0) + debt.amount);
+    }
+
+    // Filter out near-zero balances
+    const participants = Array.from(balance.entries())
+      .filter(([, v]) => Math.abs(v) > 0.0001)
+      .map(([wallet, net]) => ({ wallet, net }));
+
+    const result: SimplifiedDebtEdge[] = [];
+
+    // Work with mutable copies
+    const nets = participants.map((p) => ({ ...p }));
+
+    while (true) {
+      // Sort: most negative first (biggest debtors), most positive last (biggest creditors)
+      nets.sort((a, b) => a.net - b.net);
+
+      const debtor = nets[0];
+      const creditor = nets[nets.length - 1];
+
+      if (!debtor || !creditor) break;
+      if (Math.abs(debtor.net) < 0.0001 || Math.abs(creditor.net) < 0.0001) break;
+      if (debtor.net >= 0) break; // no more debtors
+
+      const settleAmount = Math.min(Math.abs(debtor.net), creditor.net);
+
+      result.push({
+        from: debtor.wallet,
+        to: creditor.wallet,
+        amount: Math.round(settleAmount * 1_000_000) / 1_000_000, // 7 decimal Stellar precision
+        asset,
+      });
+
+      debtor.net += settleAmount;
+      creditor.net -= settleAmount;
+
+      // Remove settled participants
+      if (Math.abs(debtor.net) < 0.0001) nets.splice(0, 1);
+      if (Math.abs(creditor.net) < 0.0001) nets.splice(nets.length - 1, 1);
+
+      if (nets.length < 2) break;
+    }
+
+    return result;
+  }
+}

--- a/backend/src/debt-simplification/debt-simplification.controller.ts
+++ b/backend/src/debt-simplification/debt-simplification.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+} from '@nestjs/common';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { DebtSimplificationService } from './debt-simplification.service';
+import {
+  CalculateDebtSimplificationDto,
+  GeneratePaymentLinksDto,
+} from './dto/debt-simplification.dto';
+import { SimplifiedDebt } from './entities/simplified-debt.entity';
+
+@UseGuards(JwtAuthGuard)
+@Controller('api/debt-simplification')
+export class DebtSimplificationController {
+  constructor(private readonly debtSimplificationService: DebtSimplificationService) {}
+
+  /**
+   * POST /api/debt-simplification/calculate
+   *
+   * Calculate or return cached simplified debts for the given user wallet addresses.
+   */
+  @Post('calculate')
+  @HttpCode(HttpStatus.OK)
+  async calculate(@Body() dto: CalculateDebtSimplificationDto): Promise<SimplifiedDebt> {
+    return this.debtSimplificationService.calculate(dto.userIds, dto.groupId);
+  }
+
+  /**
+   * GET /api/debt-simplification/group/:groupId
+   *
+   * Retrieve the latest valid cached simplification for a group.
+   */
+  @Get('group/:groupId')
+  async getByGroup(@Param('groupId') groupId: string): Promise<SimplifiedDebt> {
+    return this.debtSimplificationService.getByGroup(groupId);
+  }
+
+  /**
+   * GET /api/debt-simplification/user/:walletAddress
+   *
+   * Retrieve all valid cached simplifications that include the given wallet address.
+   */
+  @Get('user/:walletAddress')
+  async getByUser(@Param('walletAddress') walletAddress: string): Promise<SimplifiedDebt[]> {
+    return this.debtSimplificationService.getByWallet(walletAddress);
+  }
+
+  /**
+   * POST /api/debt-simplification/generate-payment-links
+   *
+   * Calculate debts and return each simplified transaction with a Stellar payment link.
+   */
+  @Post('generate-payment-links')
+  @HttpCode(HttpStatus.OK)
+  async generatePaymentLinks(@Body() dto: GeneratePaymentLinksDto): Promise<SimplifiedDebt> {
+    return this.debtSimplificationService.generatePaymentLinks(dto.userIds, dto.groupId);
+  }
+
+  /**
+   * POST /api/debt-simplification/invalidate/group/:groupId
+   *
+   * Manually invalidate cached results for a group (e.g., after a payment).
+   */
+  @Post('invalidate/group/:groupId')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async invalidateGroup(@Param('groupId') groupId: string): Promise<void> {
+    await this.debtSimplificationService.invalidateForGroup(groupId);
+  }
+}

--- a/backend/src/debt-simplification/debt-simplification.module.ts
+++ b/backend/src/debt-simplification/debt-simplification.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SimplifiedDebt } from './entities/simplified-debt.entity';
+import { Participant } from '../entities/participant.entity';
+import { Split } from '../entities/split.entity';
+import { DebtGraphService } from './debt-graph.service';
+import { DebtSimplificationService } from './debt-simplification.service';
+import { DebtSimplificationController } from './debt-simplification.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([SimplifiedDebt, Participant, Split]),
+  ],
+  providers: [DebtGraphService, DebtSimplificationService],
+  controllers: [DebtSimplificationController],
+  exports: [DebtSimplificationService],
+})
+export class DebtSimplificationModule {}

--- a/backend/src/debt-simplification/debt-simplification.service.spec.ts
+++ b/backend/src/debt-simplification/debt-simplification.service.spec.ts
@@ -1,0 +1,229 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { DebtSimplificationService } from './debt-simplification.service';
+import { DebtGraphService, RawDebt } from './debt-graph.service';
+import { SimplifiedDebt } from './entities/simplified-debt.entity';
+import { Participant } from '../entities/participant.entity';
+import { Split } from '../entities/split.entity';
+
+// ─── Mock factories ───────────────────────────────────────────────────────────
+
+const buildQbMock = () => {
+  const qb: any = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    execute: jest.fn().mockResolvedValue({ affected: 1 }),
+    getOne: jest.fn().mockResolvedValue(null),
+    getMany: jest.fn().mockResolvedValue([]),
+  };
+  return qb;
+};
+
+const buildSimplifiedDebtRepoMock = () => ({
+  createQueryBuilder: jest.fn(() => buildQbMock()),
+  findOne: jest.fn().mockResolvedValue(null),
+  find: jest.fn().mockResolvedValue([]),
+  create: jest.fn((data) => ({ ...data, id: 'test-uuid', calculatedAt: new Date() })),
+  save: jest.fn().mockImplementation((entity) => Promise.resolve({ ...entity, id: 'test-uuid' })),
+  delete: jest.fn().mockResolvedValue({ affected: 1 }),
+});
+
+const buildParticipantRepoMock = () => ({
+  createQueryBuilder: jest.fn(() => {
+    const qb = buildQbMock();
+    qb.innerJoinAndSelect = jest.fn().mockReturnThis();
+    return qb;
+  }),
+});
+
+const buildSplitRepoMock = () => ({
+  findOne: jest.fn(),
+});
+
+// ─── Test Suite ───────────────────────────────────────────────────────────────
+
+describe('DebtSimplificationService – integration', () => {
+  let module: TestingModule;
+  let service: DebtSimplificationService;
+  let graphService: DebtGraphService;
+  let simplifiedDebtRepo: ReturnType<typeof buildSimplifiedDebtRepoMock>;
+
+  beforeEach(async () => {
+    simplifiedDebtRepo = buildSimplifiedDebtRepoMock();
+
+    module = await Test.createTestingModule({
+      providers: [
+        DebtSimplificationService,
+        DebtGraphService,
+        { provide: getRepositoryToken(SimplifiedDebt), useValue: simplifiedDebtRepo },
+        { provide: getRepositoryToken(Participant), useFactory: buildParticipantRepoMock },
+        { provide: getRepositoryToken(Split), useFactory: buildSplitRepoMock },
+      ],
+    }).compile();
+
+    service = module.get<DebtSimplificationService>(DebtSimplificationService);
+    graphService = module.get<DebtGraphService>(DebtGraphService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // ─── calculate() returns cached result when fresh ─────────────────────────
+  it('returns cached result when a fresh record exists', async () => {
+    const cachedRecord: Partial<SimplifiedDebt> = {
+      id: 'cached-id',
+      calculatedForUserIds: ['walletA', 'walletB'],
+      debts: [],
+      originalTransactionCount: 3,
+      simplifiedTransactionCount: 1,
+      savingsPercentage: 66.67,
+      expiresAt: new Date(Date.now() + 1000 * 3600 * 24),
+      calculatedAt: new Date(),
+    };
+
+    // The first QBuilder call is the cache lookup
+    const cacheQb = buildQbMock();
+    cacheQb.getOne.mockResolvedValue(cachedRecord);
+    simplifiedDebtRepo.createQueryBuilder.mockReturnValueOnce(cacheQb);
+
+    const result = await service.calculate(['walletB', 'walletA']); // unsorted input
+
+    expect(result.id).toBe('cached-id');
+    expect(simplifiedDebtRepo.save).not.toHaveBeenCalled();
+  });
+
+  // ─── calculate() recalculates when no cache ──────────────────────────────
+  it('calls recalculate when no valid cache entry exists', async () => {
+    // All QBs return null / empty
+    const loadDebtsSpy = jest
+      .spyOn(graphService, 'loadRawDebts')
+      .mockResolvedValue([
+        { from: 'walletA', to: 'walletB', amount: 10, asset: 'XLM' },
+        { from: 'walletC', to: 'walletB', amount: 5, asset: 'XLM' },
+        { from: 'walletA', to: 'walletC', amount: 3, asset: 'XLM' },
+      ] as RawDebt[]);
+
+    const result = await service.calculate(['walletA', 'walletB', 'walletC']);
+
+    expect(loadDebtsSpy).toHaveBeenCalledWith(
+      expect.arrayContaining(['walletA', 'walletB', 'walletC']),
+      undefined,
+    );
+    expect(simplifiedDebtRepo.save).toHaveBeenCalledTimes(1);
+    // At most N-1 = 2 transactions
+    expect(result.simplifiedTransactionCount).toBeLessThanOrEqual(2);
+    expect(result.savingsPercentage).toBeGreaterThan(0);
+  });
+
+  // ─── generatePaymentLinks() attaches SEP-7 URIs ──────────────────────────
+  it('attaches Stellar SEP-7 payment links to each simplified debt', async () => {
+    jest.spyOn(graphService, 'loadRawDebts').mockResolvedValue([
+      { from: 'GXXX', to: 'GYYY', amount: 25, asset: 'XLM' },
+    ] as RawDebt[]);
+
+    const result = await service.generatePaymentLinks(['GXXX', 'GYYY']);
+
+    expect(result.debts).toHaveLength(1);
+    expect(result.debts[0].paymentLink).toMatch(/^stellar:GYYY/);
+    expect(result.debts[0].paymentLink).toContain('amount=25.0000000');
+    expect(result.debts[0].paymentLink).toContain('memo=StellarSplit');
+  });
+
+  // ─── Payment link for non-native asset ───────────────────────────────────
+  it('generates correct SEP-7 link for USDC asset', async () => {
+    const issuer = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+    jest.spyOn(graphService, 'loadRawDebts').mockResolvedValue([
+      { from: 'GXXX', to: 'GYYY', amount: 50.5, asset: `USDC:${issuer}` },
+    ] as RawDebt[]);
+
+    const result = await service.generatePaymentLinks(['GXXX', 'GYYY']);
+
+    const link = result.debts[0].paymentLink!;
+    expect(link).toMatch(/^stellar:GYYY/);
+    expect(link).toContain('asset_code=USDC');
+    expect(link).toContain(`asset_issuer=${issuer}`);
+  });
+
+  // ─── getByGroup() throws NotFoundException for missing group ─────────────
+  it('throws NotFoundException when no result exists for group', async () => {
+    const qb = buildQbMock();
+    qb.getOne.mockResolvedValue(null);
+    // findOne (used by getByGroup) returns null
+    simplifiedDebtRepo.findOne.mockResolvedValue(null);
+
+    await expect(service.getByGroup('nonexistent-group-id')).rejects.toThrow(
+      'No valid debt simplification found',
+    );
+  });
+
+  // ─── getByWallet() returns matching records ───────────────────────────────
+  it('returns records containing the given wallet address', async () => {
+    const mockRecords: Partial<SimplifiedDebt>[] = [
+      {
+        id: 'r1',
+        calculatedForUserIds: ['walletA', 'walletB'],
+        debts: [],
+        expiresAt: new Date(Date.now() + 3600000),
+      },
+    ];
+
+    const qb = buildQbMock();
+    qb.getMany.mockResolvedValue(mockRecords);
+    simplifiedDebtRepo.createQueryBuilder.mockReturnValue(qb);
+
+    const results = await service.getByWallet('walletA');
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('r1');
+  });
+
+  // ─── invalidateForWallets() deletes cache entries ─────────────────────────
+  it('deletes all cache entries for the given wallets', async () => {
+    const qb = buildQbMock();
+    simplifiedDebtRepo.createQueryBuilder.mockReturnValue(qb);
+
+    await service.invalidateForWallets(['walletA', 'walletB']);
+
+    expect(simplifiedDebtRepo.createQueryBuilder).toHaveBeenCalledTimes(2);
+    expect(qb.execute).toHaveBeenCalledTimes(2);
+  });
+
+  // ─── invalidateForGroup() deletes by groupId ─────────────────────────────
+  it('deletes cache entries by groupId', async () => {
+    await service.invalidateForGroup('group-123');
+    expect(simplifiedDebtRepo.delete).toHaveBeenCalledWith({ groupId: 'group-123' });
+  });
+
+  // ─── cleanExpiredCache() deletes expired entries ──────────────────────────
+  it('cleans expired cache entries', async () => {
+    simplifiedDebtRepo.delete.mockResolvedValue({ affected: 5 });
+
+    const count = await service.cleanExpiredCache();
+
+    expect(count).toBe(5);
+    expect(simplifiedDebtRepo.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ expiresAt: expect.anything() }),
+    );
+  });
+
+  // ─── Multi-currency split scenario ───────────────────────────────────────
+  it('handles multi-currency debt calculations', async () => {
+    jest.spyOn(graphService, 'loadRawDebts').mockResolvedValue([
+      { from: 'A', to: 'B', amount: 100, asset: 'XLM' },
+      { from: 'B', to: 'C', amount: 100, asset: 'XLM' },
+      { from: 'A', to: 'B', amount: 200, asset: 'USDC:ISSUER' },
+      { from: 'B', to: 'C', amount: 200, asset: 'USDC:ISSUER' },
+    ] as RawDebt[]);
+
+    const result = await service.calculate(['A', 'B', 'C']);
+
+    const xlmDebts = result.debts.filter((d) => d.asset === 'XLM');
+    const usdcDebts = result.debts.filter((d) => d.asset === 'USDC:ISSUER');
+
+    // XLM: A→B 100, B→C 100 → net: A=-100, B=0, C=+100 → 1 transaction
+    expect(xlmDebts).toHaveLength(1);
+    // USDC: same pattern
+    expect(usdcDebts).toHaveLength(1);
+  });
+});

--- a/backend/src/debt-simplification/debt-simplification.service.ts
+++ b/backend/src/debt-simplification/debt-simplification.service.ts
@@ -1,0 +1,254 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan, MoreThan } from 'typeorm';
+import { SimplifiedDebt, SimplifiedDebtEdge } from './entities/simplified-debt.entity';
+import { DebtGraphService } from './debt-graph.service';
+
+const CACHE_TTL_HOURS = 24;
+const STELLAR_PAYMENT_BASE_URL = 'https://stellarpay.io/pay'; // Stellar Web Authentication / SEP-7 style
+
+@Injectable()
+export class DebtSimplificationService {
+  private readonly logger = new Logger(DebtSimplificationService.name);
+
+  constructor(
+    @InjectRepository(SimplifiedDebt)
+    private readonly simplifiedDebtRepo: Repository<SimplifiedDebt>,
+    private readonly debtGraphService: DebtGraphService,
+  ) {}
+
+  /**
+   * Calculate (or return cached) simplified debts for a given set of user wallet addresses.
+   * Recalculates if the cache has expired.
+   */
+  async calculate(userIds: string[], groupId?: string): Promise<SimplifiedDebt> {
+    const sortedIds = [...userIds].sort();
+
+    // Try to load a valid cached result
+    const cached = await this.findValidCache(sortedIds, groupId);
+    if (cached) {
+      this.logger.log(`Returning cached debt simplification for ${sortedIds.length} users`);
+      return cached;
+    }
+
+    return this.recalculate(sortedIds, groupId);
+  }
+
+  /**
+   * Force recalculation and persist the new result.
+   */
+  async recalculate(sortedUserIds: string[], groupId?: string): Promise<SimplifiedDebt> {
+    this.logger.log(`Recalculating debts for ${sortedUserIds.length} users`);
+
+    // Load raw debts from DB
+    const rawDebts = await this.debtGraphService.loadRawDebts(sortedUserIds, groupId);
+
+    // Run simplification algorithm
+    const graphResult = this.debtGraphService.simplify(rawDebts);
+
+    // Generate Stellar payment links for each simplified transaction
+    const debtsWithLinks: SimplifiedDebtEdge[] = graphResult.simplifiedDebts.map((debt) => ({
+      ...debt,
+      paymentLink: this.generateStellarPaymentLink(debt),
+    }));
+
+    // Expire old cache entries for the same user set / group
+    await this.invalidateCacheForUsers(sortedUserIds, groupId);
+
+    // Persist new result
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + CACHE_TTL_HOURS);
+
+    const record = this.simplifiedDebtRepo.create({
+      groupId,
+      calculatedForUserIds: sortedUserIds,
+      debts: debtsWithLinks,
+      originalTransactionCount: graphResult.originalTransactionCount,
+      simplifiedTransactionCount: graphResult.simplifiedTransactionCount,
+      savingsPercentage: graphResult.savingsPercentage,
+      expiresAt,
+    });
+
+    const saved = await this.simplifiedDebtRepo.save(record);
+    this.logger.log(
+      `Saved simplified debts: ${graphResult.simplifiedTransactionCount} transactions ` +
+        `(was ${graphResult.originalTransactionCount}), ${graphResult.savingsPercentage}% savings`,
+    );
+    return saved;
+  }
+
+  /**
+   * Get the latest valid cached simplification for a group.
+   */
+  async getByGroup(groupId: string): Promise<SimplifiedDebt> {
+    const result = await this.simplifiedDebtRepo.findOne({
+      where: {
+        groupId,
+        expiresAt: MoreThan(new Date()),
+      },
+      order: { calculatedAt: 'DESC' },
+    });
+
+    if (!result) {
+      throw new NotFoundException(
+        `No valid debt simplification found for group ${groupId}. Please POST /calculate first.`,
+      );
+    }
+
+    return result;
+  }
+
+  /**
+   * Get the latest valid cached simplification that involves a given wallet address.
+   */
+  async getByWallet(walletAddress: string): Promise<SimplifiedDebt[]> {
+    // JSONB containment: calculatedForUserIds @> '[walletAddress]'
+    const results = await this.simplifiedDebtRepo
+      .createQueryBuilder('sd')
+      .where('sd."calculatedForUserIds" @> :wallet', {
+        wallet: JSON.stringify([walletAddress]),
+      })
+      .andWhere('sd."expiresAt" > :now', { now: new Date() })
+      .orderBy('sd."calculatedAt"', 'DESC')
+      .getMany();
+
+    return results;
+  }
+
+  /**
+   * Generate Stellar payment links for simplified debts, optionally recalculating first.
+   */
+  async generatePaymentLinks(userIds: string[], groupId?: string): Promise<SimplifiedDebt> {
+    const result = await this.calculate(userIds, groupId);
+
+    // Ensure all debts have payment links (they should from calculate(), but guard anyway)
+    const updatedDebts = result.debts.map((debt) => ({
+      ...debt,
+      paymentLink: debt.paymentLink ?? this.generateStellarPaymentLink(debt),
+    }));
+
+    if (updatedDebts.some((d, i) => d.paymentLink !== result.debts[i].paymentLink)) {
+      result.debts = updatedDebts;
+      await this.simplifiedDebtRepo.save(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Invalidate cached results when a relevant split is settled.
+   * Call this from payment/settlement event handlers.
+   */
+  async invalidateForWallets(walletAddresses: string[]): Promise<void> {
+    // Find all cached records that include any of the given wallets
+    for (const wallet of walletAddresses) {
+      await this.simplifiedDebtRepo
+        .createQueryBuilder()
+        .delete()
+        .from(SimplifiedDebt)
+        .where('"calculatedForUserIds" @> :wallet', {
+          wallet: JSON.stringify([wallet]),
+        })
+        .execute();
+    }
+    this.logger.log(
+      `Invalidated debt simplification cache for wallets: ${walletAddresses.join(', ')}`,
+    );
+  }
+
+  /**
+   * Invalidate cache for a group.
+   */
+  async invalidateForGroup(groupId: string): Promise<void> {
+    await this.simplifiedDebtRepo.delete({ groupId });
+    this.logger.log(`Invalidated debt simplification cache for group: ${groupId}`);
+  }
+
+  /**
+   * Clean up expired cache entries (can be called by a scheduler).
+   */
+  async cleanExpiredCache(): Promise<number> {
+    const result = await this.simplifiedDebtRepo.delete({
+      expiresAt: LessThan(new Date()),
+    });
+    const affected = result.affected ?? 0;
+    if (affected > 0) {
+      this.logger.log(`Cleaned ${affected} expired debt simplification cache entries`);
+    }
+    return affected;
+  }
+
+  // ─── Private Helpers ────────────────────────────────────────────────────────
+
+  private async findValidCache(
+    sortedUserIds: string[],
+    groupId?: string,
+  ): Promise<SimplifiedDebt | null> {
+    // Match by exact user set (JSONB equality) and unexpired
+    const qb = this.simplifiedDebtRepo
+      .createQueryBuilder('sd')
+      .where('sd."calculatedForUserIds" = :ids', {
+        ids: JSON.stringify(sortedUserIds),
+      })
+      .andWhere('sd."expiresAt" > :now', { now: new Date() });
+
+    if (groupId) {
+      qb.andWhere('sd."groupId" = :groupId', { groupId });
+    } else {
+      qb.andWhere('sd."groupId" IS NULL');
+    }
+
+    return qb.orderBy('sd."calculatedAt"', 'DESC').getOne();
+  }
+
+  private async invalidateCacheForUsers(
+    sortedUserIds: string[],
+    groupId?: string,
+  ): Promise<void> {
+    const qb = this.simplifiedDebtRepo
+      .createQueryBuilder()
+      .delete()
+      .from(SimplifiedDebt)
+      .where('"calculatedForUserIds" = :ids', {
+        ids: JSON.stringify(sortedUserIds),
+      });
+
+    if (groupId) {
+      qb.andWhere('"groupId" = :groupId', { groupId });
+    } else {
+      qb.andWhere('"groupId" IS NULL');
+    }
+
+    await qb.execute();
+  }
+
+  /**
+   * Generate a SEP-7 / Stellar Web Authentication style payment URL.
+   *
+   * Format: stellar:<destination>?amount=<amount>&asset_code=<code>&asset_issuer=<issuer>&memo=StellarSplit
+   *
+   * Falls back to a web-based payment URL for non-native assets.
+   */
+  private generateStellarPaymentLink(debt: SimplifiedDebtEdge): string {
+    const { to, amount, asset } = debt;
+    const amountStr = amount.toFixed(7);
+
+    // SEP-7 URI scheme: stellar:<destination>?...
+    if (asset === 'XLM' || asset === 'native') {
+      return `stellar:${to}?amount=${amountStr}&memo=StellarSplit&memo_type=text`;
+    }
+
+    // asset format: 'CODE:ISSUER'
+    const [assetCode, assetIssuer] = asset.split(':');
+    if (assetCode && assetIssuer) {
+      return (
+        `stellar:${to}?amount=${amountStr}` +
+        `&asset_code=${assetCode}&asset_issuer=${assetIssuer}` +
+        `&memo=StellarSplit&memo_type=text`
+      );
+    }
+
+    // Fallback web link
+    return `${STELLAR_PAYMENT_BASE_URL}?destination=${to}&amount=${amountStr}&asset=${encodeURIComponent(asset)}`;
+  }
+}

--- a/backend/src/debt-simplification/dto/debt-simplification.dto.ts
+++ b/backend/src/debt-simplification/dto/debt-simplification.dto.ts
@@ -1,0 +1,23 @@
+import { IsArray, IsOptional, IsString, ArrayMinSize } from 'class-validator';
+
+export class CalculateDebtSimplificationDto {
+  @IsArray()
+  @ArrayMinSize(2)
+  @IsString({ each: true })
+  userIds!: string[];
+
+  @IsOptional()
+  @IsString()
+  groupId?: string;
+}
+
+export class GeneratePaymentLinksDto {
+  @IsArray()
+  @ArrayMinSize(2)
+  @IsString({ each: true })
+  userIds!: string[];
+
+  @IsOptional()
+  @IsString()
+  groupId?: string;
+}

--- a/backend/src/debt-simplification/entities/simplified-debt.entity.ts
+++ b/backend/src/debt-simplification/entities/simplified-debt.entity.ts
@@ -1,0 +1,52 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+
+export interface SimplifiedDebtEdge {
+  from: string;        // wallet address
+  to: string;          // wallet address
+  amount: number;
+  asset: string;       // e.g. 'XLM', 'USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+  paymentLink?: string;
+}
+
+@Entity('simplified_debts')
+@Index(['groupId'])
+@Index(['calculatedAt'])
+@Index(['expiresAt'])
+export class SimplifiedDebt {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid', nullable: true })
+  groupId?: string;
+
+  /** Sorted array of user IDs / wallet addresses included in this calculation */
+  @Column({ type: 'jsonb' })
+  calculatedForUserIds!: string[];
+
+  /** The simplified debt graph per asset */
+  @Column({ type: 'jsonb' })
+  debts!: SimplifiedDebtEdge[];
+
+  @Column({ type: 'int', default: 0 })
+  originalTransactionCount!: number;
+
+  @Column({ type: 'int', default: 0 })
+  simplifiedTransactionCount!: number;
+
+  /** Percentage reduction: (1 - simplified/original) * 100 */
+  @Column({ type: 'decimal', precision: 5, scale: 2, default: 0 })
+  savingsPercentage!: number;
+
+  @CreateDateColumn()
+  calculatedAt!: Date;
+
+  /** Cache expires 24 hours after calculation */
+  @Column({ type: 'timestamp' })
+  expiresAt!: Date;
+}

--- a/backend/src/migrations/20260324000000-CreateSimplifiedDebtsTable.ts
+++ b/backend/src/migrations/20260324000000-CreateSimplifiedDebtsTable.ts
@@ -1,0 +1,85 @@
+import { MigrationInterface, QueryRunner, Table, TableIndex } from 'typeorm';
+
+export class CreateSimplifiedDebtsTable20260324000000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'simplified_debts',
+        columns: [
+          {
+            name: 'id',
+            type: 'uuid',
+            isPrimary: true,
+            default: 'gen_random_uuid()',
+          },
+          {
+            name: 'groupId',
+            type: 'uuid',
+            isNullable: true,
+          },
+          {
+            name: 'calculatedForUserIds',
+            type: 'jsonb',
+            isNullable: false,
+          },
+          {
+            name: 'debts',
+            type: 'jsonb',
+            isNullable: false,
+            default: "'[]'",
+          },
+          {
+            name: 'originalTransactionCount',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'simplifiedTransactionCount',
+            type: 'int',
+            default: 0,
+          },
+          {
+            name: 'savingsPercentage',
+            type: 'decimal',
+            precision: 5,
+            scale: 2,
+            default: 0,
+          },
+          {
+            name: 'calculatedAt',
+            type: 'timestamp',
+            default: 'CURRENT_TIMESTAMP',
+          },
+          {
+            name: 'expiresAt',
+            type: 'timestamp',
+            isNullable: false,
+          },
+        ],
+      }),
+      true,
+    );
+
+    await queryRunner.createIndex(
+      'simplified_debts',
+      new TableIndex({ name: 'IDX_simplified_debts_groupId', columnNames: ['groupId'] }),
+    );
+
+    await queryRunner.createIndex(
+      'simplified_debts',
+      new TableIndex({ name: 'IDX_simplified_debts_calculatedAt', columnNames: ['calculatedAt'] }),
+    );
+
+    await queryRunner.createIndex(
+      'simplified_debts',
+      new TableIndex({ name: 'IDX_simplified_debts_expiresAt', columnNames: ['expiresAt'] }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropIndex('simplified_debts', 'IDX_simplified_debts_expiresAt');
+    await queryRunner.dropIndex('simplified_debts', 'IDX_simplified_debts_calculatedAt');
+    await queryRunner.dropIndex('simplified_debts', 'IDX_simplified_debts_groupId');
+    await queryRunner.dropTable('simplified_debts', true);
+  }
+}


### PR DESCRIPTION
The min-cash-flow greedy algorithm:
- Groups debts by asset (currency) — separate graph per asset
- Computes net balance per wallet (credits − debits)
- Repeatedly pairs the largest debtor with the largest creditor
- Produces at most N−1 transactions for N participants — the theoretical minimum
- Guarantees net balances are identical to the original debt graph

Cache Invalidation
- Automatic: expires after 24 hours
- Manual: `invalidateForGroup()` and `invalidateForWallets()` — call these from your payment/settlement event handlers

Closes #145 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  - Debt simplification calculates minimum transactions needed to settle participant balances
  - Automatic Stellar SEP-7 payment link generation for payments
  - Cached simplification results with 24-hour expiration
  - Multi-currency debt simplification with per-asset optimization
  - Cache invalidation and retrieval endpoints

* **Tests**
  - Added integration tests for simplification service and algorithm validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->