### PR TITLE
Issue: Add Participant Cap per Escrow

### DIFF
--- a/contracts/split-escrow/src/errors.rs
+++ b/contracts/split-escrow/src/errors.rs
@@ -12,4 +12,5 @@ pub enum Error {
     SplitNotPending = 7,
     SplitNotReady = 8,
     TreasuryNotSet = 9,
+    ParticipantCapExceeded = 10,
 }

--- a/contracts/split-escrow/src/lib.rs
+++ b/contracts/split-escrow/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env, String};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Vec};
 
 mod errors;
 mod events;
@@ -11,6 +11,19 @@ mod types;
 
 pub use crate::errors::Error;
 pub use crate::types::{Split, SplitStatus};
+
+const DEFAULT_MAX_PARTICIPANTS: u32 = 50;
+
+fn participant_known(participants: &Vec<Address>, addr: &Address) -> bool {
+    let mut i = 0u32;
+    while i < participants.len() {
+        if participants.get(i).unwrap() == *addr {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
 
 #[contract]
 pub struct SplitEscrowContract;
@@ -29,17 +42,24 @@ impl SplitEscrowContract {
         Ok(())
     }
 
-    pub fn create_split(
+    /// Create an escrow split. If `max_participants` is `None`, the cap defaults to 50.
+    pub fn create_escrow(
         env: Env,
         creator: Address,
         description: String,
         total_amount: i128,
+        max_participants: Option<u32>,
     ) -> Result<u64, Error> {
         if !storage::has_admin(&env) {
             return Err(Error::NotInitialized);
         }
         creator.require_auth();
         if total_amount <= 0 {
+            return Err(Error::InvalidAmount);
+        }
+
+        let cap = max_participants.unwrap_or(DEFAULT_MAX_PARTICIPANTS);
+        if cap == 0 {
             return Err(Error::InvalidAmount);
         }
 
@@ -53,6 +73,8 @@ impl SplitEscrowContract {
             total_amount,
             deposited_amount: 0,
             status: SplitStatus::Pending,
+            max_participants: cap,
+            participants: Vec::new(&env),
         };
         storage::set_split(&env, &split);
         events::emit_split_created(&env, &split);
@@ -76,6 +98,13 @@ impl SplitEscrowContract {
         }
         if split.deposited_amount + amount > split.total_amount {
             return Err(Error::InvalidAmount);
+        }
+
+        if !participant_known(&split.participants, &participant) {
+            if split.participants.len() >= split.max_participants {
+                return Err(Error::ParticipantCapExceeded);
+            }
+            split.participants.push_back(participant.clone());
         }
 
         let token_address = storage::get_token(&env);
@@ -123,7 +152,9 @@ impl SplitEscrowContract {
         fees::set_treasury(&env, &address)
     }
 
-    pub fn get_split(env: Env, split_id: u64) -> Result<Split, Error> {
+    /// Returns escrow state including `max_participants` and `participants` (count =
+    /// `participants.len()`).
+    pub fn get_escrow(env: Env, split_id: u64) -> Result<Split, Error> {
         storage::get_split(&env, split_id).ok_or(Error::SplitNotFound)
     }
 }

--- a/contracts/split-escrow/src/test.rs
+++ b/contracts/split-escrow/src/test.rs
@@ -51,18 +51,18 @@ fn test_fee_deducted_and_sent_to_treasury_on_release() {
     client.set_treasury(&treasury);
     client.set_fee(&250u32); // 2.5%
 
-    let split_id = client.create_split(&creator, &String::from_str(&env, "Dinner"), &10_000);
+    let split_id =
+        client.create_escrow(&creator, &String::from_str(&env, "Dinner"), &10_000, &None);
     client.deposit(&split_id, &participant, &10_000);
     client.release_funds(&split_id);
 
-    // 2.5% of 10_000 = 250
     assert_eq!(token_client.balance(&treasury), 250);
     assert_eq!(token_client.balance(&creator), 9_750);
 
-    let split = client.get_split(&split_id);
-    assert_eq!(split.status, SplitStatus::Released);
+    let escrow = client.get_escrow(&split_id);
+    assert_eq!(escrow.status, SplitStatus::Released);
 
-    let _ = admin; // Silence potential unused variable in some toolchains.
+    let _ = admin;
 }
 
 #[test]
@@ -71,18 +71,18 @@ fn test_admin_can_update_fee_and_treasury() {
 
     let treasury_a = Address::generate(&env);
     client.set_treasury(&treasury_a);
-    client.set_fee(&100u32); // 1%
+    client.set_fee(&100u32);
 
-    let split_a = client.create_split(&creator, &String::from_str(&env, "A"), &1_000);
+    let split_a = client.create_escrow(&creator, &String::from_str(&env, "A"), &1_000, &None);
     client.deposit(&split_a, &participant, &1_000);
     client.release_funds(&split_a);
     assert_eq!(token_client.balance(&treasury_a), 10);
 
     let treasury_b = Address::generate(&env);
     client.set_treasury(&treasury_b);
-    client.set_fee(&300u32); // 3%
+    client.set_fee(&300u32);
 
-    let split_b = client.create_split(&creator, &String::from_str(&env, "B"), &2_000);
+    let split_b = client.create_escrow(&creator, &String::from_str(&env, "B"), &2_000, &None);
     client.deposit(&split_b, &participant, &2_000);
     client.release_funds(&split_b);
     assert_eq!(token_client.balance(&treasury_b), 60);
@@ -96,8 +96,6 @@ fn test_set_fee_and_set_treasury_are_admin_only() {
     client.set_fee(&123u32);
     client.set_treasury(&Address::generate(&env));
 
-    // The contract enforces auth on stored admin; these calls should still require admin auth.
-    // This assertion validates admin was configured and methods are callable in authorized context.
     assert_ne!(admin, Address::generate(&env));
 }
 
@@ -106,14 +104,95 @@ fn test_fees_collected_event_emitted() {
     let (env, client, _admin, creator, participant, _token_client, _) = setup();
     let treasury = Address::generate(&env);
     client.set_treasury(&treasury);
-    client.set_fee(&500u32); // 5%
+    client.set_fee(&500u32);
 
     let before_len = env.events().all().len();
 
-    let split_id = client.create_split(&creator, &String::from_str(&env, "Event"), &1_000);
+    let split_id = client.create_escrow(&creator, &String::from_str(&env, "Event"), &1_000, &None);
     client.deposit(&split_id, &participant, &1_000);
     client.release_funds(&split_id);
 
     let after_len = env.events().all().len();
     assert!(after_len > before_len);
+}
+
+#[test]
+fn test_default_max_participants_is_50() {
+    let (env, client, _admin, creator, _p, _tc, token_admin) = setup();
+    let escrow_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Cap default"),
+        &100,
+        &None,
+    );
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.max_participants, 50);
+    assert_eq!(escrow.participants.len(), 0);
+
+    let _ = token_admin;
+}
+
+#[test]
+fn test_explicit_max_participants_stored_in_get_escrow() {
+    let (env, client, _admin, creator, p1, _tc, _ta) = setup();
+    let cap = 3u32;
+    let escrow_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Explicit cap"),
+        &300,
+        &Some(cap),
+    );
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.max_participants, cap);
+    client.deposit(&escrow_id, &p1, &100);
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.participants.len(), 1);
+}
+
+#[test]
+fn test_deposit_rejected_when_participant_cap_exceeded() {
+    let (env, client, _admin, creator, p1, _tc, token_admin) = setup();
+    let p2 = Address::generate(&env);
+    let p3 = Address::generate(&env);
+    token_admin.mint(&p2, &10_000);
+    token_admin.mint(&p3, &10_000);
+
+    let escrow_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Two max"),
+        &3_000,
+        &Some(2u32),
+    );
+
+    client.deposit(&escrow_id, &p1, &1_000);
+    client.deposit(&escrow_id, &p2, &1_000);
+    assert_eq!(client.get_escrow(&escrow_id).participants.len(), 2);
+
+    let res = client.try_deposit(&escrow_id, &p3, &1_000);
+    assert!(res.is_err());
+
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.participants.len(), 2);
+    assert_eq!(escrow.deposited_amount, 2_000);
+}
+
+#[test]
+fn test_existing_participant_can_deposit_again_without_increasing_count() {
+    let (env, client, _admin, creator, p1, _tc, _ta) = setup();
+    // release_funds runs fee collection; treasury must be set even when fee bps is 0.
+    client.set_treasury(&Address::generate(&env));
+
+    let escrow_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Repeat"),
+        &2_000,
+        &Some(1u32),
+    );
+    client.deposit(&escrow_id, &p1, &1_000);
+    client.deposit(&escrow_id, &p1, &1_000);
+    let escrow = client.get_escrow(&escrow_id);
+    assert_eq!(escrow.participants.len(), 1);
+    assert_eq!(escrow.deposited_amount, 2_000);
+    client.release_funds(&escrow_id);
+    assert_eq!(client.get_escrow(&escrow_id).status, SplitStatus::Released);
 }

--- a/contracts/split-escrow/src/types.rs
+++ b/contracts/split-escrow/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracttype, Address, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -8,6 +8,7 @@ pub enum SplitStatus {
     Released,
 }
 
+/// Escrow split state. `participants.len()` is the current distinct participant count.
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Split {
@@ -17,4 +18,8 @@ pub struct Split {
     pub total_amount: i128,
     pub deposited_amount: i128,
     pub status: SplitStatus,
+    /// Maximum distinct participants allowed (default 50 at creation if not specified).
+    pub max_participants: u32,
+    /// Distinct addresses that have deposited; length is the current participant count.
+    pub participants: Vec<Address>,
 }


### PR DESCRIPTION
Closes #198 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Escrows now support configurable participant caps (default: 50 participants)
  * Deposits rejected when adding a new participant would exceed the configured cap

* **Refactor**
  * Updated API: `create_split` renamed to `create_escrow` with new `max_participants` parameter
  * Updated API: `get_split` renamed to `get_escrow`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->