### PR TITLE
Add metadata handling to SplitEscrow contract

### DIFF
--- a/contracts/split-escrow/src/errors.rs
+++ b/contracts/split-escrow/src/errors.rs
@@ -13,4 +13,6 @@ pub enum Error {
     SplitNotReady = 8,
     TreasuryNotSet = 9,
     ParticipantCapExceeded = 10,
+    SplitNotActive = 11,
+    InvalidMetadata = 12,
 }

--- a/contracts/split-escrow/src/lib.rs
+++ b/contracts/split-escrow/src/lib.rs
@@ -1,6 +1,6 @@
 #![no_std]
 
-use soroban_sdk::{contract, contractimpl, token, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, token, Address, Env, Map, String, Vec};
 
 mod errors;
 mod events;
@@ -13,6 +13,8 @@ pub use crate::errors::Error;
 pub use crate::types::{Split, SplitStatus};
 
 const DEFAULT_MAX_PARTICIPANTS: u32 = 50;
+const MAX_METADATA_ENTRIES: u32 = 5;
+const MAX_METADATA_STRING_LEN: u32 = 64;
 
 fn participant_known(participants: &Vec<Address>, addr: &Address) -> bool {
     let mut i = 0u32;
@@ -23,6 +25,29 @@ fn participant_known(participants: &Vec<Address>, addr: &Address) -> bool {
         i += 1;
     }
     false
+}
+
+fn validate_metadata(metadata: &Map<String, String>) -> Result<(), Error> {
+    if metadata.len() > MAX_METADATA_ENTRIES {
+        return Err(Error::InvalidMetadata);
+    }
+
+    let keys = metadata.keys();
+    let mut i = 0u32;
+    while i < keys.len() {
+        let key = keys.get(i).unwrap();
+        let value = metadata.get(key.clone()).unwrap();
+        if key.len() > MAX_METADATA_STRING_LEN || value.len() > MAX_METADATA_STRING_LEN {
+            return Err(Error::InvalidMetadata);
+        }
+        i += 1;
+    }
+
+    Ok(())
+}
+
+fn is_active(status: &SplitStatus) -> bool {
+    *status != SplitStatus::Released
 }
 
 #[contract]
@@ -49,6 +74,7 @@ impl SplitEscrowContract {
         description: String,
         total_amount: i128,
         max_participants: Option<u32>,
+        metadata: Option<Map<String, String>>,
     ) -> Result<u64, Error> {
         if !storage::has_admin(&env) {
             return Err(Error::NotInitialized);
@@ -63,6 +89,9 @@ impl SplitEscrowContract {
             return Err(Error::InvalidAmount);
         }
 
+        let metadata = metadata.unwrap_or(Map::new(&env));
+        validate_metadata(&metadata)?;
+
         let split_id = storage::get_next_split_id(&env);
         storage::bump_next_split_id(&env);
 
@@ -70,6 +99,7 @@ impl SplitEscrowContract {
             split_id,
             creator,
             description,
+            metadata,
             total_amount,
             deposited_amount: 0,
             status: SplitStatus::Pending,
@@ -156,5 +186,28 @@ impl SplitEscrowContract {
     /// `participants.len()`).
     pub fn get_escrow(env: Env, split_id: u64) -> Result<Split, Error> {
         storage::get_split(&env, split_id).ok_or(Error::SplitNotFound)
+    }
+
+    pub fn get_metadata(env: Env, split_id: u64) -> Result<Map<String, String>, Error> {
+        let split = storage::get_split(&env, split_id).ok_or(Error::SplitNotFound)?;
+        Ok(split.metadata)
+    }
+
+    pub fn update_metadata(
+        env: Env,
+        split_id: u64,
+        metadata: Map<String, String>,
+    ) -> Result<(), Error> {
+        validate_metadata(&metadata)?;
+
+        let mut split = storage::get_split(&env, split_id).ok_or(Error::SplitNotFound)?;
+        split.creator.require_auth();
+        if !is_active(&split.status) {
+            return Err(Error::SplitNotActive);
+        }
+
+        split.metadata = metadata;
+        storage::set_split(&env, &split);
+        Ok(())
     }
 }

--- a/contracts/split-escrow/src/test.rs
+++ b/contracts/split-escrow/src/test.rs
@@ -2,7 +2,17 @@
 
 use crate::{SplitEscrowContract, SplitEscrowContractClient, SplitStatus};
 use soroban_sdk::token::{Client as TokenClient, StellarAssetClient as TokenAdminClient};
-use soroban_sdk::{testutils::Address as _, testutils::Events as _, Address, Env, String};
+use soroban_sdk::{
+    testutils::Address as _, testutils::Events as _, Address, Env, Map, String,
+};
+
+fn metadata_map(env: &Env, entries: &[(&str, &str)]) -> Map<String, String> {
+    let mut metadata = Map::new(env);
+    for (key, value) in entries {
+        metadata.set(String::from_str(env, key), String::from_str(env, value));
+    }
+    metadata
+}
 
 fn setup() -> (
     Env,
@@ -52,7 +62,7 @@ fn test_fee_deducted_and_sent_to_treasury_on_release() {
     client.set_fee(&250u32); // 2.5%
 
     let split_id =
-        client.create_escrow(&creator, &String::from_str(&env, "Dinner"), &10_000, &None);
+        client.create_escrow(&creator, &String::from_str(&env, "Dinner"), &10_000, &None, &None);
     client.deposit(&split_id, &participant, &10_000);
     client.release_funds(&split_id);
 
@@ -73,7 +83,8 @@ fn test_admin_can_update_fee_and_treasury() {
     client.set_treasury(&treasury_a);
     client.set_fee(&100u32);
 
-    let split_a = client.create_escrow(&creator, &String::from_str(&env, "A"), &1_000, &None);
+    let split_a =
+        client.create_escrow(&creator, &String::from_str(&env, "A"), &1_000, &None, &None);
     client.deposit(&split_a, &participant, &1_000);
     client.release_funds(&split_a);
     assert_eq!(token_client.balance(&treasury_a), 10);
@@ -82,7 +93,8 @@ fn test_admin_can_update_fee_and_treasury() {
     client.set_treasury(&treasury_b);
     client.set_fee(&300u32);
 
-    let split_b = client.create_escrow(&creator, &String::from_str(&env, "B"), &2_000, &None);
+    let split_b =
+        client.create_escrow(&creator, &String::from_str(&env, "B"), &2_000, &None, &None);
     client.deposit(&split_b, &participant, &2_000);
     client.release_funds(&split_b);
     assert_eq!(token_client.balance(&treasury_b), 60);
@@ -108,7 +120,8 @@ fn test_fees_collected_event_emitted() {
 
     let before_len = env.events().all().len();
 
-    let split_id = client.create_escrow(&creator, &String::from_str(&env, "Event"), &1_000, &None);
+    let split_id =
+        client.create_escrow(&creator, &String::from_str(&env, "Event"), &1_000, &None, &None);
     client.deposit(&split_id, &participant, &1_000);
     client.release_funds(&split_id);
 
@@ -123,6 +136,7 @@ fn test_default_max_participants_is_50() {
         &creator,
         &String::from_str(&env, "Cap default"),
         &100,
+        &None,
         &None,
     );
     let escrow = client.get_escrow(&escrow_id);
@@ -141,6 +155,7 @@ fn test_explicit_max_participants_stored_in_get_escrow() {
         &String::from_str(&env, "Explicit cap"),
         &300,
         &Some(cap),
+        &None,
     );
     let escrow = client.get_escrow(&escrow_id);
     assert_eq!(escrow.max_participants, cap);
@@ -162,6 +177,7 @@ fn test_deposit_rejected_when_participant_cap_exceeded() {
         &String::from_str(&env, "Two max"),
         &3_000,
         &Some(2u32),
+        &None,
     );
 
     client.deposit(&escrow_id, &p1, &1_000);
@@ -187,6 +203,7 @@ fn test_existing_participant_can_deposit_again_without_increasing_count() {
         &String::from_str(&env, "Repeat"),
         &2_000,
         &Some(1u32),
+        &None,
     );
     client.deposit(&escrow_id, &p1, &1_000);
     client.deposit(&escrow_id, &p1, &1_000);
@@ -195,4 +212,116 @@ fn test_existing_participant_can_deposit_again_without_increasing_count() {
     assert_eq!(escrow.deposited_amount, 2_000);
     client.release_funds(&escrow_id);
     assert_eq!(client.get_escrow(&escrow_id).status, SplitStatus::Released);
+}
+
+#[test]
+fn test_metadata_stored_on_create_and_returned() {
+    let (env, client, _admin, creator, _participant, _token_client, _token_admin) = setup();
+    let metadata = metadata_map(
+        &env,
+        &[
+            ("title", "Team dinner"),
+            ("description", "March closeout"),
+            ("category", "food"),
+        ],
+    );
+
+    let split_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Dinner"),
+        &2_500,
+        &None,
+        &Some(metadata.clone()),
+    );
+
+    let escrow = client.get_escrow(&split_id);
+    assert_eq!(escrow.metadata, metadata);
+    assert_eq!(client.get_metadata(&split_id), metadata);
+}
+
+#[test]
+fn test_creator_can_update_metadata_while_active() {
+    let (env, client, _admin, creator, _participant, _token_client, _token_admin) = setup();
+    let split_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Project"),
+        &5_000,
+        &None,
+        &Some(metadata_map(&env, &[("title", "Initial")])),
+    );
+
+    let updated = metadata_map(
+        &env,
+        &[("title", "Launch"), ("description", "Q2 kickoff")],
+    );
+    client.update_metadata(&split_id, &updated);
+
+    assert_eq!(client.get_metadata(&split_id), updated);
+    assert_eq!(client.get_escrow(&split_id).metadata, updated);
+}
+
+#[test]
+fn test_update_metadata_rejected_after_release() {
+    let (env, client, _admin, creator, participant, _token_client, _token_admin) = setup();
+    client.set_treasury(&Address::generate(&env));
+
+    let split_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Closed"),
+        &1_000,
+        &None,
+        &None,
+    );
+    client.deposit(&split_id, &participant, &1_000);
+    client.release_funds(&split_id);
+
+    let result = client.try_update_metadata(&split_id, &metadata_map(&env, &[("title", "Nope")]));
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_create_escrow_rejects_metadata_with_too_many_keys() {
+    let (env, client, _admin, creator, _participant, _token_client, _token_admin) = setup();
+    let metadata = metadata_map(
+        &env,
+        &[
+            ("k1", "v1"),
+            ("k2", "v2"),
+            ("k3", "v3"),
+            ("k4", "v4"),
+            ("k5", "v5"),
+            ("k6", "v6"),
+        ],
+    );
+
+    let result = client.try_create_escrow(
+        &creator,
+        &String::from_str(&env, "Too many"),
+        &100,
+        &None,
+        &Some(metadata),
+    );
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_update_metadata_rejects_overlong_values() {
+    let (env, client, _admin, creator, _participant, _token_client, _token_admin) = setup();
+    let split_id = client.create_escrow(
+        &creator,
+        &String::from_str(&env, "Long"),
+        &100,
+        &None,
+        &None,
+    );
+
+    let long_value = String::from_str(
+        &env,
+        "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+    );
+    let mut metadata = Map::new(&env);
+    metadata.set(String::from_str(&env, "title"), long_value);
+
+    let result = client.try_update_metadata(&split_id, &metadata);
+    assert!(result.is_err());
 }

--- a/contracts/split-escrow/src/types.rs
+++ b/contracts/split-escrow/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, String, Vec};
+use soroban_sdk::{contracttype, Address, Map, String, Vec};
 
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -15,6 +15,7 @@ pub struct Split {
     pub split_id: u64,
     pub creator: Address,
     pub description: String,
+    pub metadata: Map<String, String>,
     pub total_amount: i128,
     pub deposited_amount: i128,
     pub status: SplitStatus,


### PR DESCRIPTION
closes #199
- Introduced metadata field in Split struct.
- Implemented metadata validation logic.
- Updated create_escrow and update_metadata functions to handle metadata.
- Added tests for metadata creation and updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Splits now support optional metadata—attach custom key-value information during escrow creation and retrieve it anytime
- Update metadata on active splits; metadata updates are restricted once funds are released
- Built-in validation prevents excessive metadata entries and enforces string length limits

<!-- end of auto-generated comment: release notes by coderabbit.ai -->