### PR TITLE
feat: add workspace, expand CI, validate staking, add template versioning

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -1,0 +1,36 @@
+[workspace]
+resolver = "2"
+
+members = [
+    "achievement-badges",
+    "flash-loan",
+    "path-payment",
+    "split-template",
+    "staking",
+]
+# Excluded: these crates have compilation errors and are not yet workspace-ready
+# - dispute-resolution: many compilation errors (mid-port to pinned Soroban toolchain)
+# - split-escrow: many compilation errors (draft/broken source)
+# - multi-sig-splits: E0507 move error (needs ownership fix)
+exclude = [
+    "dispute-resolution",
+    "split-escrow",
+    "multi-sig-splits",
+]
+
+[workspace.dependencies]
+soroban-sdk = "21.0.0"
+
+[profile.release]
+opt-level = "z"
+overflow-checks = true
+debug = 0
+strip = "symbols"
+debug-assertions = false
+panic = "abort"
+codegen-units = 1
+lto = true
+
+[profile.release-with-logs]
+inherits = "release"
+debug-assertions = true

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -6,44 +6,56 @@ This directory contains the Soroban smart contracts for the StellarSplit escrow 
 
 The StellarSplit contracts handle on-chain escrow for bill splitting, enabling trustless payments between participants.
 
+## Workspace
+
+All healthy contracts are managed as a Cargo workspace from `contracts/Cargo.toml`.
+Run workspace-wide commands from the `contracts/` directory:
+
+```bash
+cd contracts
+cargo test --workspace        # run all tests
+cargo fmt --all -- --check    # check formatting
+cargo build --workspace --target wasm32-unknown-unknown --release  # build all WASMs
+```
+
+Or use the CI script:
+
+```bash
+bash scripts/ci-contracts.sh all    # fmt + test + build for all supported contracts
+bash scripts/ci-contracts.sh fmt    # formatting only
+bash scripts/ci-contracts.sh test   # tests only
+bash scripts/ci-contracts.sh build  # WASM build only
+```
+
+## Contract Status
+
+| Contract | Status | Tests | Notes |
+|----------|--------|-------|-------|
+| achievement-badges | Production | Yes | NFT achievement badges |
+| flash-loan | Production | Yes | Flash loan protocol |
+| path-payment | Production | Yes | Automatic currency conversion via Stellar path payments |
+| split-template | Production | Yes | Reusable split templates with versioning |
+| staking | Production | Yes | Staking, governance delegation, and reward distribution |
+| dispute-resolution | Broken | - | Many compilation errors; mid-port to pinned Soroban toolchain |
+| split-escrow | Broken | - | Many compilation errors; draft/broken source |
+| multi-sig-splits | Broken | - | E0507 move error; needs ownership fix |
+
 ## Project Structure
 
 ```
 contracts/
-├── achievement-badges/     # NFT achievement badges
-│   ├── src/
-│   │   ├── lib.rs          # Badge minting contract
-│   │   ├── types.rs        # Badge types and metadata
-│   │   ├── storage.rs      # Badge storage helpers
-│   │   ├── events.rs       # Badge events
-│   │   └── test.rs         # Badge tests
-│   ├── Cargo.toml          # Rust dependencies
-│   └── README.md           # Badge contract docs
-├── multi-sig-splits/       # Multi-signature with time-locks
-│   ├── src/
-│   │   ├── lib.rs          # Multi-sig contract
-│   │   ├── types.rs        # Multi-sig types
-│   │   ├── storage.rs      # Multi-sig storage
-│   │   ├── events.rs       # Multi-sig events
-│   │   └── test.rs         # Multi-sig tests
-│   ├── Cargo.toml          # Rust dependencies
-│   └── README.md           # Multi-sig contract docs
-├── split-escrow/           # Main escrow contract
-│   ├── src/
-│   │   ├── lib.rs          # Contract entry point
-│   │   ├── types.rs        # Custom data types
-│   │   ├── storage.rs      # Storage helpers
-│   │   ├── events.rs       # Contract events
-│   │   └── test.rs         # Unit tests
-│   ├── Cargo.toml          # Rust dependencies
-│   └── README.md           # Contract documentation
+├── Cargo.toml                 # Workspace root (soroban-sdk centralized)
+├── achievement-badges/        # NFT achievement badges
+├── flash-loan/                # Flash loan protocol
+├── path-payment/              # Path payment currency conversion
+├── split-template/            # Reusable split templates (versioned)
+├── staking/                   # Staking, governance & rewards
+├── dispute-resolution/        # (excluded - broken)
+├── split-escrow/              # (excluded - broken)
+├── multi-sig-splits/          # (excluded - broken)
 ├── scripts/
-│   ├── build.sh                    # Build split-escrow contract
-│   ├── build-achievement-badges.sh # Build achievement badges contract
-│   ├── build-multi-sig-splits.sh   # Build multi-sig splits contract
-│   ├── deploy.sh                   # Deploy to network
-│   └── test.sh                     # Run unit tests
-└── README.md                       # This file
+│   └── ci-contracts.sh        # CI: fmt, test, build for supported contracts
+└── README.md                  # This file
 ```
 
 ## Prerequisites
@@ -74,29 +86,27 @@ cargo install soroban-cli
 ```bash
 cd contracts
 
-# Build main escrow contract
-./scripts/build.sh
+# Build all workspace contracts to WASM
+cargo build --workspace --target wasm32-unknown-unknown --release
 
-# Build achievement badges contract
-./scripts/build-achievement-badges.sh
-
-# Build multi-signature contract
-./scripts/build-multi-sig-splits.sh
+# Or use the CI script
+bash scripts/ci-contracts.sh build
 ```
-
-Each script compiles the respective contract to WebAssembly and optionally optimizes it.
 
 ### Run Tests
 
 ```bash
-./scripts/test.sh
-```
+cd contracts
 
-Run specific tests:
+# Run all workspace tests
+cargo test --workspace
 
-```bash
-./scripts/test.sh create_split
-./scripts/test.sh --verbose
+# Run tests for a specific contract
+cargo test -p staking-governance
+cargo test -p split-template
+
+# Or use the CI script
+bash scripts/ci-contracts.sh test
 ```
 
 ### Deploy to Testnet

--- a/contracts/achievement-badges/Cargo.toml
+++ b/contracts/achievement-badges/Cargo.toml
@@ -11,21 +11,7 @@ repository = "https://github.com/OlufunbiIK/StellarSplit"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/flash-loan/Cargo.toml
+++ b/contracts/flash-loan/Cargo.toml
@@ -7,20 +7,7 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = false
-panic = "abort"
-lto = true
-codegen-units = 1
-
-[profile.release-with-logs]
-inherits = "release"
-debug = true
-archive-strip-bool = false
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/path-payment/Cargo.toml
+++ b/contracts/path-payment/Cargo.toml
@@ -11,21 +11,7 @@ repository = "https://github.com/OlufunbiIK/StellarSplit"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/scripts/ci-contracts.sh
+++ b/contracts/scripts/ci-contracts.sh
@@ -5,15 +5,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONTRACTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# `split-escrow` is intentionally excluded for now because the Rust source in
-# `contracts/split-escrow/src/lib.rs` is draft/broken and does not parse.
-# `dispute-resolution` is also excluded because the contract/test API is still
-# mid-port and does not compile under the pinned Soroban toolchain yet.
-# `multi-sig-splits`, `path-payment`, `split-template`, and `staking` are
-# excluded until they are verified clean under the pinned Soroban toolchain.
+# Supported contracts: all crates that compile cleanly under the pinned Soroban toolchain.
+#
+# Excluded (broken):
+# - dispute-resolution: many compilation errors (mid-port to pinned Soroban toolchain)
+# - split-escrow: many compilation errors (draft/broken source)
+# - multi-sig-splits: E0507 move error (needs ownership fix)
 SUPPORTED_CONTRACTS=(
   "achievement-badges"
   "flash-loan"
+  "path-payment"
+  "split-template"
+  "staking"
 )
 
 COMMAND="${1:-all}"
@@ -36,16 +39,27 @@ run_for_contract() {
       cargo build --manifest-path "$manifest" --target wasm32-unknown-unknown --release
       ;;
     *)
-      echo "Unsupported command: $COMMAND"
-      echo "Usage: bash ./scripts/ci-contracts.sh [fmt|test|build]"
+      echo "Unsupported command: $COMMAND (expected fmt, test, build, or all)"
+      echo "Usage: bash ./scripts/ci-contracts.sh [fmt|test|build|all]"
       exit 1
       ;;
   esac
 }
 
-for contract in "${SUPPORTED_CONTRACTS[@]}"; do
-  run_for_contract "$contract"
-done
+if [ "$COMMAND" = "all" ]; then
+  # Run fmt, test, and build sequentially for all supported contracts
+  for step in fmt test build; do
+    COMMAND="$step"
+    for contract in "${SUPPORTED_CONTRACTS[@]}"; do
+      run_for_contract "$contract"
+    done
+  done
+  COMMAND="all"
+else
+  for contract in "${SUPPORTED_CONTRACTS[@]}"; do
+    run_for_contract "$contract"
+  done
+fi
 
 echo ""
 echo "All contract checks completed for: ${SUPPORTED_CONTRACTS[*]}"

--- a/contracts/split-template/Cargo.toml
+++ b/contracts/split-template/Cargo.toml
@@ -11,21 +11,7 @@ repository = "https://github.com/OlufunbiIK/StellarSplit"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/split-template/src/events.rs
+++ b/contracts/split-template/src/events.rs
@@ -4,11 +4,17 @@
 
 use soroban_sdk::{Address, Env, String, Symbol};
 
-/// Emit an event when a template is created.
-pub fn emit_template_created(env: &Env, template_id: String, creator: Address, name: String) {
+/// Emit an event when a template is created (includes schema version).
+pub fn emit_template_created(
+    env: &Env,
+    template_id: String,
+    creator: Address,
+    name: String,
+    version: u32,
+) {
     env.events().publish(
         (Symbol::new(env, "template_created"), template_id),
-        (creator, name),
+        (creator, name, version),
     );
 }
 

--- a/contracts/split-template/src/lib.rs
+++ b/contracts/split-template/src/lib.rs
@@ -21,6 +21,10 @@ pub use storage::*;
 pub use types::*;
 pub use utils::*;
 
+/// Current template schema version. Bump when the Template struct or contract
+/// semantics change in a backwards-incompatible way.
+pub const CURRENT_TEMPLATE_VERSION: u32 = 1;
+
 /// The Split Template contract for managing reusable split configurations.
 #[contract]
 pub struct SplitTemplateContract;
@@ -70,6 +74,7 @@ impl SplitTemplateContract {
             name,
             split_type,
             participants,
+            version: CURRENT_TEMPLATE_VERSION,
         };
 
         // Store the template
@@ -78,8 +83,14 @@ impl SplitTemplateContract {
         // Add to creator's index for efficient lookup
         storage::add_to_creator_index(&env, &creator, template_id.clone());
 
-        // Emit event
-        events::emit_template_created(&env, template_id.clone(), creator, template.name.clone());
+        // Emit event (includes version)
+        events::emit_template_created(
+            &env,
+            template_id.clone(),
+            creator,
+            template.name.clone(),
+            CURRENT_TEMPLATE_VERSION,
+        );
 
         Ok(template_id)
     }
@@ -142,6 +153,22 @@ impl SplitTemplateContract {
     /// The template if found, or an error
     pub fn get_template(env: Env, template_id: String) -> Result<Template, Error> {
         storage::get_template(&env, &template_id).ok_or(Error::TemplateNotFound)
+    }
+
+    /// Return the current template version used by this contract.
+    ///
+    /// Useful for off-chain tooling to detect contract upgrades.
+    pub fn get_template_version(_env: Env) -> u32 {
+        CURRENT_TEMPLATE_VERSION
+    }
+
+    /// Check whether a given version is compatible with the current contract.
+    ///
+    /// Returns `true` when `version` equals `CURRENT_TEMPLATE_VERSION`.
+    /// Callers can use this before attempting to deserialize or apply a template
+    /// that was created by a potentially different contract version.
+    pub fn is_compatible(_env: Env, version: u32) -> bool {
+        version == CURRENT_TEMPLATE_VERSION
     }
 
     // ============================================

--- a/contracts/split-template/src/test.rs
+++ b/contracts/split-template/src/test.rs
@@ -349,6 +349,52 @@ mod tests {
     }
 
     // ============================================
+    // Versioning Tests
+    // ============================================
+
+    #[test]
+    fn test_get_template_version() {
+        let (_env, _creator, client) = setup();
+
+        let version = client.get_template_version();
+        assert_eq!(version, 1);
+    }
+
+    #[test]
+    fn test_is_compatible_current_version() {
+        let (_env, _creator, client) = setup();
+
+        assert!(client.is_compatible(&1));
+    }
+
+    #[test]
+    fn test_is_not_compatible_old_version() {
+        let (_env, _creator, client) = setup();
+
+        assert!(!client.is_compatible(&0));
+    }
+
+    #[test]
+    fn test_is_not_compatible_future_version() {
+        let (_env, _creator, client) = setup();
+
+        assert!(!client.is_compatible(&2));
+    }
+
+    #[test]
+    fn test_template_stores_version() {
+        let (env, creator, client) = setup();
+
+        let name = SorobanString::from_str(&env, "Versioned Template");
+        let participants = create_equal_split_participants(&env, 2);
+
+        let template_id = client.create_template(&creator, &name, &SplitType::Equal, &participants);
+
+        let template = client.get_template(&template_id);
+        assert_eq!(template.version, 1);
+    }
+
+    // ============================================
     // Edge Cases
     // ============================================
 

--- a/contracts/split-template/src/types.rs
+++ b/contracts/split-template/src/types.rs
@@ -40,6 +40,8 @@ pub struct Template {
     pub split_type: SplitType,
     /// List of participants and their shares
     pub participants: Vec<Participant>,
+    /// Template schema version
+    pub version: u32,
 }
 
 /// Contract errors
@@ -53,4 +55,6 @@ pub enum Error {
     InvalidParticipants = 2,
     /// Shares are invalid for the given split type
     InvalidShares = 3,
+    /// Template version is incompatible with the current contract
+    IncompatibleVersion = 4,
 }

--- a/contracts/staking/Cargo.toml
+++ b/contracts/staking/Cargo.toml
@@ -11,21 +11,7 @@ repository = "https://github.com/OlufunbiIK/StellarSplit"
 crate-type = ["cdylib"]
 
 [dependencies]
-soroban-sdk = "21.0.0"
+soroban-sdk = { workspace = true }
 
 [dev-dependencies]
-soroban-sdk = { version = "21.0.0", features = ["testutils"] }
-
-[profile.release]
-opt-level = "z"
-overflow-checks = true
-debug = 0
-strip = "symbols"
-debug-assertions = false
-panic = "abort"
-codegen-units = 1
-lto = true
-
-[profile.release-with-logs]
-inherits = "release"
-debug-assertions = true
+soroban-sdk = { workspace = true, features = ["testutils"] }


### PR DESCRIPTION
## Summary

### Rust Workspace (#268)
- Create `contracts/Cargo.toml` workspace with 5 healthy members
- Centralize `soroban-sdk = 21.0.0` as workspace dependency
- Exclude 3 broken crates (dispute-resolution, split-escrow, multi-sig-splits) with documented reasons

### CI Expansion (#269)
- Expand `ci-contracts.sh` from 2 to 5 contracts (add path-payment, split-template, staking)
- Add `all` command that runs fmt + test + build sequentially

### Staking Validation (#267)
- Verified staking contract compiles, 3 tests pass (stake/unstake, rewards, delegation)
- Marked as production-viable in `contracts/README.md` status table

### Template Versioning (#266)
- Add `version: u32` field to `Template` struct with `CURRENT_TEMPLATE_VERSION = 1`
- Add `get_template_version()` and `is_compatible(version)` public methods
- Include version in template creation events
- Add `IncompatibleVersion` error variant and 5 versioning tests

28 workspace tests pass. CI script verified for all 5 contracts.

Closes #266
Closes #267
Closes #268
Closes #269

## Test plan
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --workspace` — 28/28 pass
- [x] `bash scripts/ci-contracts.sh fmt` — all 5 contracts pass
- [x] `bash scripts/ci-contracts.sh test` — all 5 contracts pass
- [ ] CI: contracts-ci job passes (fmt + test + build + WASM artifacts)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template versioning support to split-template contract with version retrieval and compatibility checking capabilities

* **Documentation**
  * Updated project documentation with workspace configuration details and contract production status information

* **Chores**
  * Consolidated cross-contract dependencies through workspace management
  * Enhanced CI pipeline for unified contract building, testing, and formatting across the workspace

<!-- end of auto-generated comment: release notes by coderabbit.ai -->