### PR TITLE
fix(ci): update WASM artifact path for workspace target directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,5 +133,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: contract-wasm
-          path: contracts/*/target/wasm32-unknown-unknown/release/*.wasm
+          path: contracts/target/wasm32-unknown-unknown/release/*.wasm
           if-no-files-found: error


### PR DESCRIPTION
## Summary
The workspace `Cargo.toml` merged in #278 outputs WASM builds to `contracts/target/` (shared workspace target) instead of `contracts/*/target/` (per-crate targets). This fixes the `Upload WASM artifacts` CI step that was failing with "No files were found."

## Test plan
- [ ] CI contracts job passes with WASM artifact upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration for contract artifact uploads to use a consolidated target directory, streamlining the artifact collection process during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->