### PR TITLE
Route-level error + pending boundaries

### DIFF
--- a/frontend/src/components/routing/RouteErrorBoundary.tsx
+++ b/frontend/src/components/routing/RouteErrorBoundary.tsx
@@ -1,0 +1,68 @@
+import {
+  Link,
+  isRouteErrorResponse,
+  useLocation,
+  useRouteError,
+} from "react-router-dom";
+
+function getErrorMessage(error: unknown): string {
+  if (isRouteErrorResponse(error)) {
+    if (typeof error.data === "string" && error.data.trim()) return error.data;
+    if (typeof error.statusText === "string" && error.statusText.trim())
+      return error.statusText;
+    return `Request failed (${error.status})`;
+  }
+
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "Something went wrong while loading the current screen.";
+}
+
+export default function RouteErrorBoundary() {
+  const error = useRouteError();
+  const { pathname } = useLocation();
+  const message = getErrorMessage(error);
+
+  return (
+    <section
+      className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-4xl items-center justify-center p-6 sm:p-8"
+      role="alert"
+      aria-live="polite"
+      data-testid="route-error-boundary"
+    >
+      <div className="w-full rounded-3xl border border-theme bg-card-theme p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
+          Page Error
+        </p>
+        <h1 className="mt-3 text-2xl font-semibold text-theme">
+          We could not render this page
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-theme">
+          {message}
+        </p>
+
+        <div className="mt-6 flex flex-wrap gap-3">
+          <a
+            href={pathname}
+            className="rounded-full bg-accent px-4 py-2 text-sm font-semibold text-white"
+          >
+            Try Again
+          </a>
+          <Link
+            to="/dashboard"
+            className="rounded-full border border-theme px-4 py-2 text-sm font-semibold text-theme"
+          >
+            Open Dashboard
+          </Link>
+          <Link
+            to="/"
+            className="rounded-full border border-theme px-4 py-2 text-sm font-semibold text-theme"
+          >
+            Go Home
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/components/routing/RoutePending.tsx
+++ b/frontend/src/components/routing/RoutePending.tsx
@@ -1,0 +1,29 @@
+export type RoutePendingProps = {
+  title?: string;
+  testId?: string;
+};
+
+export default function RoutePending({
+  title = "Loading…",
+  testId = "route-pending",
+}: RoutePendingProps) {
+  return (
+    <section
+      className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-4xl items-center justify-center p-6 sm:p-8"
+      aria-busy="true"
+      role="status"
+      data-testid={testId}
+    >
+      <div className="w-full rounded-3xl border border-theme bg-card-theme p-6 shadow-sm sm:p-8">
+        <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
+          Loading
+        </p>
+        <h1 className="mt-3 text-2xl font-semibold text-theme">{title}</h1>
+        <div className="mt-6 h-2 w-full overflow-hidden rounded-full bg-muted-theme/20">
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-accent/70" />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/frontend/src/layouts/RootLayout.tsx
+++ b/frontend/src/layouts/RootLayout.tsx
@@ -1,78 +1,7 @@
-import { Component, type ReactNode, useEffect, useState } from "react";
-import { Link, Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation } from "react-router-dom";
+import { useEffect, useState } from "react";
 import Navbar from "../components/Navbar";
 import Sidebar from "../components/SIdebar";
-
-type ShellErrorBoundaryProps = {
-  children: ReactNode;
-  resetKey: string;
-};
-
-type ShellErrorBoundaryState = {
-  error: Error | null;
-};
-
-class ShellErrorBoundary extends Component<
-  ShellErrorBoundaryProps,
-  ShellErrorBoundaryState
-> {
-  state: ShellErrorBoundaryState = {
-    error: null,
-  };
-
-  static getDerivedStateFromError(error: Error): ShellErrorBoundaryState {
-    return { error };
-  }
-
-  componentDidUpdate(prevProps: ShellErrorBoundaryProps) {
-    if (prevProps.resetKey !== this.props.resetKey && this.state.error) {
-      this.setState({ error: null });
-    }
-  }
-
-  handleRetry = () => {
-    this.setState({ error: null });
-  };
-
-  render() {
-    if (this.state.error) {
-      return (
-        <section className="mx-auto flex min-h-[calc(100vh-3.5rem)] w-full max-w-4xl items-center justify-center p-6 sm:p-8">
-          <div className="w-full rounded-3xl border border-theme bg-card-theme p-6 shadow-sm sm:p-8">
-            <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
-              Page Error
-            </p>
-            <h1 className="mt-3 text-2xl font-semibold text-theme">
-              We could not render this page
-            </h1>
-            <p className="mt-3 max-w-2xl text-sm leading-6 text-muted-theme">
-              {this.state.error.message ||
-                "Something went wrong while loading the current screen."}
-            </p>
-
-            <div className="mt-6 flex flex-wrap gap-3">
-              <button
-                type="button"
-                onClick={this.handleRetry}
-                className="rounded-full bg-accent px-4 py-2 text-sm font-semibold text-white"
-              >
-                Try Again
-              </button>
-              <Link
-                to="/dashboard"
-                className="rounded-full border border-theme px-4 py-2 text-sm font-semibold text-theme"
-              >
-                Open Dashboard
-              </Link>
-            </div>
-          </div>
-        </section>
-      );
-    }
-
-    return this.props.children;
-  }
-}
 
 export default function RootLayout() {
   const { pathname } = useLocation();
@@ -92,9 +21,7 @@ export default function RootLayout() {
       <div className="min-h-screen lg:pl-[14rem]">
         <Navbar onMenuOpen={() => setIsSidebarOpen(true)} />
         <main id="main-content" className="min-h-[calc(100vh-3.5rem)]">
-          <ShellErrorBoundary resetKey={pathname}>
-            <Outlet />
-          </ShellErrorBoundary>
+          <Outlet />
         </main>
       </div>
     </div>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,8 @@ import RootLayout from "./layouts/RootLayout";
 import { WalletProvider } from "./hooks/use-wallet";
 import { ThemeProvider } from "./components/ThemeContext";
 import { CollaborationProvider } from "./components/Collaboration";
+import RouteErrorBoundary from "./components/routing/RouteErrorBoundary";
+import RoutePending from "./components/routing/RoutePending";
 import { bootstrapTheme } from "./utils/themeBootstrap";
 import "./i18n/config";
 
@@ -17,6 +19,8 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <RootLayout />,
+    errorElement: <RouteErrorBoundary />,
+    hydrateFallbackElement: <RoutePending />,
     children: [
       { index: true, element: <HomePage /> },
       {

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,34 @@
 import '@testing-library/jest-dom';
+
+import "../i18n/config";
+
+// Ensure a stable Storage implementation across jsdom/happy-dom.
+// Some environments provide a partial localStorage without `clear()`.
+const memoryStorage = () => {
+  let store: Record<string, string> = {};
+  return {
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+    getItem: (key: string) => (key in store ? store[key] : null),
+    setItem: (key: string, value: string) => {
+      store[key] = String(value);
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+};
+
+if (
+  typeof globalThis.localStorage === "undefined" ||
+  typeof (globalThis.localStorage as any).clear !== "function"
+) {
+  (globalThis as unknown as { localStorage: Storage }).localStorage =
+    memoryStorage() as unknown as Storage;
+}
+

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
+    globals: true,
+    restoreMocks: true,
+    clearMocks: true,
+  },
+});
+


### PR DESCRIPTION
## Summary
- Adds route-level `errorElement` handling so lazy-route/render errors are isolated per screen.
- Adds a consistent pending fallback for lazy routes using React Router `hydrateFallbackElement`.
- Removes the shell-only error boundary from `RootLayout` now that routes own their boundaries.

## Notes
- Added `frontend/vitest.config.ts` + `src/test/setup.ts` polyfills to stabilize test environment storage.

## Issue
Closes #355
Closes #356 
Closes #357 
Closes #358 

## Test plan
- `cd frontend && npm run build`
- `cd frontend && npm run lint`
- `cd frontend && npm test`

M
* **New Features**
  * Route-level error handling with multiple recovery options (retry current page, navigate to dashboard, navigate home)
  * Loading indicator displayed during page transitions with accessibility announcements

* **Improvements**
  * Enhanced hydration fallback experience during app initialization

* **Chores**
  * Improved test setup and configuration for enhanced testing environment

