### PR TITLE
Feature/pwa service worker lifecycle

### DIFF
--- a/backend/src/audit-trail/audit-report.json
+++ b/backend/src/audit-trail/audit-report.json
@@ -1,11 +1,7 @@
 {
-  "generatedAt": "2026-04-21T20:08:18.615Z",
-  "totalEvents": 6,
+  "generatedAt": "2026-04-23T22:37:29.382Z",
+  "totalEvents": 2,
   "actions": [
-    "test",
-    "login",
-    "test",
-    "login",
     "test",
     "login"
   ],

--- a/backend/src/auth/guards/jwt-auth.guard.spec.ts
+++ b/backend/src/auth/guards/jwt-auth.guard.spec.ts
@@ -111,6 +111,8 @@ describe("JwtAuthGuard", () => {
     expect(context.switchToHttp().getRequest().user).toEqual({
       id: "dev-user",
       walletAddress: "dev-user",
+      raw: { sub: "dev-user" },
+      wallet: "dev-user",
     });
   });
 });

--- a/backend/src/batch/batch.controller.spec.ts
+++ b/backend/src/batch/batch.controller.spec.ts
@@ -8,6 +8,7 @@ import {
 } from "./dto/create-batch.dto";
 import { BatchStatusDto } from "./dto/batch-status.dto";
 import { BatchJobStatus, BatchJobType } from "./entities/batch-job.entity";
+import { ReceiptPolicyService } from "../receipts/receipt-policy.service";
 
 describe("BatchController", () => {
   let controller: BatchController;
@@ -45,6 +46,14 @@ describe("BatchController", () => {
             canManageGroupMembers: jest.fn().mockResolvedValue(true),
             canCreateGroupSplit: jest.fn().mockResolvedValue(true),
             filterAccessibleSplits: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: ReceiptPolicyService,
+          useValue: {
+            canCreateReceipt: jest.fn().mockResolvedValue(true),
+            canAccessReceipt: jest.fn().mockResolvedValue(true),
+            canDeleteReceipt: jest.fn().mockResolvedValue(true),
           },
         },
       ],

--- a/backend/src/collaboration/collaboration.controller.spec.ts
+++ b/backend/src/collaboration/collaboration.controller.spec.ts
@@ -7,6 +7,13 @@ import {
     CollaborationType,
 } from "./entities/collaboration.entity";
 import { Artist } from "../artists/entities/artist.entity";
+import { AuthUser } from "../auth/types/auth-user.interface";
+
+const authUser = (wallet: string): AuthUser => ({
+    id: wallet,
+    walletAddress: wallet,
+    raw: { sub: wallet },
+});
 
 describe("CollaborationController", () => {
     let controller: CollaborationController;
@@ -90,7 +97,7 @@ describe("CollaborationController", () => {
             );
 
             const result = await controller.createCollaboration(
-                { user: { wallet: "inviter-wallet" } } as any,
+                authUser("inviter-wallet"),
                 createDto,
             );
 
@@ -114,7 +121,7 @@ describe("CollaborationController", () => {
             );
 
             const result = await controller.getCollaborations(
-                { user: { wallet: "user-wallet" } } as any,
+                authUser("user-wallet"),
                 CollaborationStatus.INVITED,
                 "1",
                 "10",
@@ -136,9 +143,10 @@ describe("CollaborationController", () => {
                 mockCollaboration,
             );
 
-            const result = await controller.getCollaborationById("collab-id", {
-                user: { wallet: "user-wallet" },
-            } as any);
+            const result = await controller.getCollaborationById(
+                "collab-id",
+                authUser("user-wallet"),
+            );
 
             expect(service.getCollaborationById).toHaveBeenCalledWith(
                 "collab-id",
@@ -169,7 +177,7 @@ describe("CollaborationController", () => {
 
             const result = await controller.respondToCollaboration(
                 "collab-id",
-                { user: { wallet: "artist-wallet" } } as any,
+                authUser("artist-wallet"),
                 responseDto,
             );
 
@@ -202,7 +210,7 @@ describe("CollaborationController", () => {
 
             const result = await controller.removeCollaboration(
                 "collab-id",
-                { user: { wallet: "inviter-wallet" } } as any,
+                authUser("inviter-wallet"),
                 removeDto,
             );
 
@@ -228,9 +236,9 @@ describe("CollaborationController", () => {
 
             mockService.getCollaborationStats.mockResolvedValue(mockStats);
 
-            const result = await controller.getCollaborationStats({
-                user: { wallet: "user-wallet" },
-            } as any);
+            const result = await controller.getCollaborationStats(
+                authUser("user-wallet"),
+            );
 
             expect(service.getCollaborationStats).toHaveBeenCalledWith(
                 "user-wallet",

--- a/backend/src/invitations/invitations.controller.spec.ts
+++ b/backend/src/invitations/invitations.controller.spec.ts
@@ -3,6 +3,7 @@ import { HttpStatus } from "@nestjs/common";
 import { InvitationsController } from "./invitations.controller";
 import { InvitationsService } from "./invitations.service";
 import { AuthorizationService } from "../auth/services/authorization.service";
+import { ReceiptPolicyService } from "../receipts/receipt-policy.service";
 import { Invitation } from "./invitation.entity";
 import { CreateInvitationDto } from "./dto/create-invitation.dto";
 import { JoinInvitationDto } from "./dto/join-invitation.dto";
@@ -72,6 +73,14 @@ describe("InvitationsController", () => {
             canManageGroupMembers: jest.fn().mockResolvedValue(true),
             canCreateGroupSplit: jest.fn().mockResolvedValue(true),
             filterAccessibleSplits: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: ReceiptPolicyService,
+          useValue: {
+            canCreateReceipt: jest.fn().mockResolvedValue(true),
+            canAccessReceipt: jest.fn().mockResolvedValue(true),
+            canDeleteReceipt: jest.fn().mockResolvedValue(true),
           },
         },
       ],

--- a/backend/src/profile/profile.controller.spec.ts
+++ b/backend/src/profile/profile.controller.spec.ts
@@ -1,8 +1,12 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { NotFoundException } from '@nestjs/common';
+import { CanActivate, NotFoundException } from '@nestjs/common';
 import { ProfileController } from './profile.controller';
 import { ProfileService } from './profile.service';
 import { UserProfile, DefaultSplitType } from './profile.entity';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ProfilePolicyGuard } from './profile-policy.guard';
+
+const allowAllGuard: CanActivate = { canActivate: () => true };
 
 describe('ProfileController', () => {
   let controller: ProfileController;
@@ -40,7 +44,12 @@ describe('ProfileController', () => {
           useValue: mockProfileService,
         },
       ],
-    }).compile();
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(allowAllGuard)
+      .overrideGuard(ProfilePolicyGuard)
+      .useValue(allowAllGuard)
+      .compile();
 
     controller = module.get<ProfileController>(ProfileController);
     profileService = module.get<ProfileService>(ProfileService);
@@ -73,7 +82,10 @@ describe('ProfileController', () => {
         displayName: 'Alice Updated',
         preferredCurrency: 'EUR' as const,
       };
-      const result = await controller.update(walletAddress, dto);
+      const req = {
+        user: { walletAddress, id: 'user-id' },
+      };
+      const result = await controller.update(walletAddress, dto, req);
       expect(result).toEqual(mockProfile);
       expect(profileService.update).toHaveBeenCalledWith(walletAddress, dto);
     });

--- a/backend/src/recurring-splits/recurring-splits.controller.spec.ts
+++ b/backend/src/recurring-splits/recurring-splits.controller.spec.ts
@@ -9,6 +9,7 @@ import { RecurringSplitsScheduler } from "./recurring-splits.scheduler";
 import { RecurringSplit, RecurrenceFrequency } from "./recurring-split.entity";
 import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { AuthorizationService } from "../auth/services/authorization.service";
+import { ReceiptPolicyService } from "../receipts/receipt-policy.service";
 
 describe("RecurringSplitsController", () => {
   let controller: RecurringSplitsController;
@@ -59,6 +60,14 @@ describe("RecurringSplitsController", () => {
             canManageGroupMembers: jest.fn().mockResolvedValue(true),
             canCreateGroupSplit: jest.fn().mockResolvedValue(true),
             filterAccessibleSplits: jest.fn().mockResolvedValue([]),
+          },
+        },
+        {
+          provide: ReceiptPolicyService,
+          useValue: {
+            canCreateReceipt: jest.fn().mockResolvedValue(true),
+            canAccessReceipt: jest.fn().mockResolvedValue(true),
+            canDeleteReceipt: jest.fn().mockResolvedValue(true),
           },
         },
       ],

--- a/backend/src/security/security.middleware.ts
+++ b/backend/src/security/security.middleware.ts
@@ -1,5 +1,9 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
-import { Request, Response, NextFunction } from 'express';
+import type {
+  NextFunction,
+  Request,
+  Response,
+} from 'express-serve-static-core';
 import helmet from 'helmet';
 import xssClean from 'xss-clean';
 import csrf from 'csurf';
@@ -28,11 +32,11 @@ export class SecurityMiddleware implements NestMiddleware {
   });
 
   use(req: Request, res: Response, next: NextFunction): void {
-    this.helmetHandler(req, res, (helmetError?: Error) => {
-      if (helmetError) return next(helmetError);
+    this.helmetHandler(req, res, (helmetError?: unknown) => {
+      if (helmetError) return next(helmetError as Error);
 
-      this.xssCleanHandler(req, res, (xssError?: Error) => {
-        if (xssError) return next(xssError);
+      this.xssCleanHandler(req, res, (xssError?: unknown) => {
+        if (xssError) return next(xssError as Error);
 
         if (this.isProduction) {
           res.setHeader('X-Content-Type-Options', 'nosniff');
@@ -44,8 +48,8 @@ export class SecurityMiddleware implements NestMiddleware {
           );
         }
 
-        this.rateLimitHandler(req, res, (rateLimitError?: Error) => {
-          if (rateLimitError) return next(rateLimitError);
+        this.rateLimitHandler(req, res, (rateLimitError?: unknown) => {
+          if (rateLimitError) return next(rateLimitError as Error);
 
           if (this.enableCsrf) {
             this.csrfHandler(req, res, next);

--- a/backend/src/split-template/split-template.controller.spec.ts
+++ b/backend/src/split-template/split-template.controller.spec.ts
@@ -4,12 +4,17 @@ import { SplitTemplateService } from "./split-template.service";
 import { CreateSplitTemplateDto } from "./dto/create-split-template.dto";
 import { CreateSplitFromTemplateDto } from "./dto/create-split-from-template.dto";
 import { SplitType } from "./entities/split-template.entity";
+import { AuthUser } from "../auth/types/auth-user.interface";
 
 describe("SplitTemplateController", () => {
     let controller: SplitTemplateController;
     let service: SplitTemplateService;
 
-    const mockUser = { wallet: "test-wallet-address" };
+    const mockUser: AuthUser = {
+        id: "test-wallet-address",
+        walletAddress: "test-wallet-address",
+        raw: { sub: "test-wallet-address" },
+    };
 
     const mockTemplate = {
         id: "test-id",
@@ -66,13 +71,10 @@ describe("SplitTemplateController", () => {
 
             mockSplitTemplateService.create.mockResolvedValue(mockTemplate);
 
-            const result = await controller.create(
-                { user: mockUser } as any,
-                createDto,
-            );
+            const result = await controller.create(mockUser, createDto);
 
             expect(service.create).toHaveBeenCalledWith(
-                mockUser.wallet,
+                mockUser.walletAddress,
                 createDto,
             );
             expect(result).toEqual(mockTemplate);
@@ -86,10 +88,10 @@ describe("SplitTemplateController", () => {
                 templates,
             );
 
-            const result = await controller.findAll({ user: mockUser } as any);
+            const result = await controller.findAll(mockUser);
 
             expect(service.findAllForUser).toHaveBeenCalledWith(
-                mockUser.wallet,
+                mockUser.walletAddress,
             );
             expect(result).toEqual(templates);
         });

--- a/contracts/dispute-resolution/src/test.rs
+++ b/contracts/dispute-resolution/src/test.rs
@@ -45,11 +45,14 @@ fn setup() -> (
     escrow_client.set_treasury(&treasury);
     escrow_client.set_fee(&0u32);
 
+    let mut obligations = Map::new(&env);
+    obligations.set(participant.clone(), 10_000i128);
     let escrow_split_id = escrow_client.create_escrow(
         &creator,
         &String::from_str(&env, "Escrow split for disputes"),
         &10_000i128,
         &Map::new(&env),
+        &obligations,
         &None,
         &false,
         &None,

--- a/contracts/path-payment/src/test.rs
+++ b/contracts/path-payment/src/test.rs
@@ -29,7 +29,7 @@ fn test_swap_failure_event_emitted() {
     let res = client.try_execute_path_payment(&caller, &split_id, &path, &amount, &0u32);
     assert!(res.is_err());
 
-    // Check that swap_fail event was emitted
+    // Check that swap_err event was emitted (see events::emit_swap_failed; topic is swap_err for symbol limit)
     let events = env.events().all();
     let found = events.iter().any(|e| {
         let (addr, topics, data) = e;
@@ -37,7 +37,7 @@ fn test_swap_failure_event_emitted() {
             return false;
         }
 
-        let target_symbol = soroban_sdk::symbol_short!("swap_fail");
+        let target_symbol = soroban_sdk::symbol_short!("swap_err");
         let mut topic_found = false;
         for t in topics.iter() {
             if let Ok(sym) = Symbol::try_from_val(&env, &t) {
@@ -55,7 +55,7 @@ fn test_swap_failure_event_emitted() {
         }
         false
     });
-    assert!(found, "swap_fail event should be emitted on swap failure");
+    assert!(found, "swap_err event should be emitted on swap failure");
 }
 
 extern crate std;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,15 +1,11 @@
-import { useEffect, useRef } from "react";
-import { registerServiceWorker } from "./utils/sw-register";
+import { useRef } from "react";
 import { SplitDetailPage } from "./pages/SplitView/SplitDetailPage";
 
 function App() {
   const announceRef = useRef<HTMLDivElement>(null);
 
   // Function to announce messages to screen readers
-
-  useEffect(() => {
-    registerServiceWorker();
-  }, []);
+  // Service worker registration is handled in `main.tsx`
 
   return (
     <>

--- a/frontend/src/components/InstallPrompt.test.tsx
+++ b/frontend/src/components/InstallPrompt.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useServiceWorkerStore } from "../store/serviceWorkerStore";
+import InstallPrompt from "./InstallPrompt";
+
+const applyServiceWorkerUpdate = vi.fn();
+const forceRefreshWithCacheClear = vi.fn().mockResolvedValue(undefined);
+const registerServiceWorker = vi.fn().mockResolvedValue(undefined);
+
+vi.mock("../utils/sw-register", () => ({
+  applyServiceWorkerUpdate: () => applyServiceWorkerUpdate(),
+  forceRefreshWithCacheClear: () => forceRefreshWithCacheClear(),
+  registerServiceWorker: () => registerServiceWorker(),
+}));
+
+const installApp = vi.fn();
+const { mockUsePWA } = vi.hoisted(() => ({
+  mockUsePWA: vi.fn(),
+}));
+
+vi.mock("../hooks/usePWA", () => ({
+  usePWA: () => mockUsePWA() as ReturnType<typeof import("../hooks/usePWA").usePWA>,
+}));
+
+describe("InstallPrompt", () => {
+  beforeEach(() => {
+    useServiceWorkerStore.getState().reset();
+    applyServiceWorkerUpdate.mockClear();
+    forceRefreshWithCacheClear.mockClear();
+    registerServiceWorker.mockClear();
+    installApp.mockClear();
+    mockUsePWA.mockReturnValue({
+      isOnline: true,
+      installPrompt: null,
+      installApp,
+    });
+  });
+
+  afterEach(() => {
+    useServiceWorkerStore.getState().reset();
+  });
+
+  it("wires 'Reload to update' to applyServiceWorkerUpdate", () => {
+    act(() => {
+      useServiceWorkerStore.getState().setPhase("ready");
+      useServiceWorkerStore.getState().setUpdateAvailable();
+    });
+    render(<InstallPrompt />);
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /reload to update/i }),
+      );
+    });
+    expect(applyServiceWorkerUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires 'Full refresh (clear cache)' to forceRefreshWithCacheClear", () => {
+    act(() => {
+      useServiceWorkerStore.getState().setPhase("ready");
+      useServiceWorkerStore.getState().setUpdateAvailable();
+    });
+    render(<InstallPrompt />);
+    act(() => {
+      fireEvent.click(
+        screen.getByRole("button", { name: /full refresh \(clear cache\)/i }),
+      );
+    });
+    expect(forceRefreshWithCacheClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires 'Try again' in error state to registerServiceWorker", () => {
+    act(() => {
+      useServiceWorkerStore.getState().setError("Registration failed");
+    });
+    render(<InstallPrompt />);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    });
+    expect(registerServiceWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it("wires the PWA install button to installApp when beforeinstallprompt was captured", () => {
+    mockUsePWA.mockReturnValue({
+      isOnline: true,
+      installPrompt: {} as unknown,
+      installApp,
+    });
+    act(() => {
+      useServiceWorkerStore.getState().setPhase("ready");
+    });
+    render(<InstallPrompt />);
+    expect(screen.getByText(/install stellarsplit/i)).toBeInTheDocument();
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: /^install$/i }));
+    });
+    expect(installApp).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/components/InstallPrompt.tsx
+++ b/frontend/src/components/InstallPrompt.tsx
@@ -1,19 +1,115 @@
-import { usePWA } from '../hooks/usePWA';
+import { usePWA } from "../hooks/usePWA";
+import { useServiceWorkerStore } from "../store/serviceWorkerStore";
+import {
+  applyServiceWorkerUpdate,
+  forceRefreshWithCacheClear,
+  registerServiceWorker,
+} from "../utils/sw-register";
 
 const InstallPrompt = () => {
   const { installPrompt, installApp } = usePWA();
+  const phase = useServiceWorkerStore((s) => s.phase);
+  const error = useServiceWorkerStore((s) => s.error);
+  const clearError = useServiceWorkerStore((s) => s.clearError);
+  const dismissUpdateBanner = useServiceWorkerStore(
+    (s) => s.dismissUpdateBanner,
+  );
 
-  if (!installPrompt) return null;
+  const showPwaCard = installPrompt;
+  const showUpdate = phase === "update_available";
+  const showError = phase === "error" && error;
+  if (!showPwaCard && !showUpdate && !showError) return null;
 
   return (
-    <div className="fixed bottom-4 right-4 bg-black text-white p-4 rounded-lg shadow-lg">
-      <p>Install StellarSplit for a better experience</p>
-      <button
-        onClick={installApp}
-        className="mt-2 bg-blue-600 px-4 py-2 rounded"
-      >
-        Install
-      </button>
+    <div
+      className="pointer-events-auto fixed bottom-4 right-4 z-[200] flex max-w-md flex-col gap-3"
+      data-testid="pwa-floating-cta"
+    >
+      {showUpdate && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="rounded-xl border border-theme bg-card-theme p-4 text-theme shadow-lg"
+        >
+          <p className="text-sm font-semibold">A new version is available</p>
+          <p className="mt-1 text-sm text-muted-theme">
+            Reload the app to use the latest StellarSplit. You can do a full
+            refresh to clear cached assets if something still looks out of
+            date.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => applyServiceWorkerUpdate()}
+              className="rounded-lg bg-accent px-3 py-1.5 text-sm font-medium text-white"
+            >
+              Reload to update
+            </button>
+            <button
+              type="button"
+              onClick={() => void forceRefreshWithCacheClear()}
+              className="rounded-lg border border-theme px-3 py-1.5 text-sm font-medium text-theme"
+            >
+              Full refresh (clear cache)
+            </button>
+            <button
+              type="button"
+              onClick={dismissUpdateBanner}
+              className="rounded-lg px-3 py-1.5 text-sm text-muted-theme hover:underline"
+            >
+              Not now
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showError && (
+        <div
+          role="alert"
+          className="rounded-xl border border-red-500/40 bg-red-50 p-4 text-sm text-red-900 shadow-lg dark:bg-red-950/40 dark:text-red-100"
+        >
+          <p className="font-semibold">App update could not be prepared</p>
+          <p className="mt-1 opacity-90">{error}</p>
+          <div className="mt-2 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => {
+                void registerServiceWorker();
+              }}
+              className="rounded-lg bg-red-700 px-3 py-1.5 text-sm font-medium text-white dark:bg-red-600"
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={() => void clearError()}
+              className="rounded-lg px-3 py-1.5 text-sm underline"
+            >
+              Dismiss
+            </button>
+            <button
+              type="button"
+              onClick={() => void forceRefreshWithCacheClear()}
+              className="rounded-lg border border-red-500/50 px-3 py-1.5 text-sm font-medium"
+            >
+              Full refresh
+            </button>
+          </div>
+        </div>
+      )}
+
+      {showPwaCard && (
+        <div className="rounded-lg bg-zinc-900 p-4 text-white shadow-lg">
+          <p>Install StellarSplit for a better experience</p>
+          <button
+            type="button"
+            onClick={installApp}
+            className="mt-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white"
+          >
+            Install
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -11,6 +11,8 @@ import RouteErrorBoundary from "./components/routing/RouteErrorBoundary";
 import RoutePending from "./components/routing/RoutePending";
 import { bootstrapTheme } from "./utils/themeBootstrap";
 import "./i18n/config";
+import InstallPrompt from "./components/InstallPrompt";
+import { registerServiceWorker } from "./utils/sw-register";
 
 // Apply theme before hydration to prevent flash
 bootstrapTheme();
@@ -84,11 +86,14 @@ const router = createBrowserRouter([
   },
 ]);
 
+void registerServiceWorker();
+
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <ThemeProvider>
       <WalletProvider>
         <CollaborationProvider>
+          <InstallPrompt />
           <RouterProvider router={router} />
         </CollaborationProvider>
       </WalletProvider>

--- a/frontend/src/store/serviceWorkerStore.test.ts
+++ b/frontend/src/store/serviceWorkerStore.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { useServiceWorkerStore } from "./serviceWorkerStore";
+
+describe("serviceWorkerStore", () => {
+  afterEach(() => {
+    useServiceWorkerStore.getState().reset();
+  });
+
+  it("starts idle", () => {
+    expect(useServiceWorkerStore.getState().phase).toBe("idle");
+  });
+
+  it("setError sets error phase and clearError recovers from error to idle", () => {
+    useServiceWorkerStore.getState().setError("boom");
+    expect(useServiceWorkerStore.getState().phase).toBe("error");
+    expect(useServiceWorkerStore.getState().error).toBe("boom");
+    useServiceWorkerStore.getState().clearError();
+    expect(useServiceWorkerStore.getState().error).toBeNull();
+    expect(useServiceWorkerStore.getState().phase).toBe("idle");
+  });
+
+  it("setUpdateAvailable is ignored while in error", () => {
+    useServiceWorkerStore.getState().setError("failed");
+    useServiceWorkerStore.getState().setUpdateAvailable();
+    expect(useServiceWorkerStore.getState().phase).toBe("error");
+  });
+
+  it("dismissUpdateBanner returns to ready", () => {
+    useServiceWorkerStore.getState().setPhase("ready");
+    useServiceWorkerStore.getState().setUpdateAvailable();
+    expect(useServiceWorkerStore.getState().phase).toBe("update_available");
+    useServiceWorkerStore.getState().dismissUpdateBanner();
+    expect(useServiceWorkerStore.getState().phase).toBe("ready");
+  });
+});

--- a/frontend/src/store/serviceWorkerStore.ts
+++ b/frontend/src/store/serviceWorkerStore.ts
@@ -1,0 +1,67 @@
+import { create } from "zustand";
+
+/**
+ * PWA / service worker UI state. Updated by `registerServiceWorker` in sw-register
+ * and by user actions (dismiss, retry) from InstallPrompt.
+ */
+export type ServiceWorkerUiPhase =
+  | "idle"
+  | "registering"
+  | "ready"
+  | "update_available"
+  | "error"
+  | "unsupported";
+
+export type ServiceWorkerStore = {
+  phase: ServiceWorkerUiPhase;
+  error: string | null;
+
+  setPhase: (phase: ServiceWorkerUiPhase) => void;
+  setError: (message: string | null) => void;
+  setUpdateAvailable: () => void;
+  /** Hide the "new version" bar until a future update is detected. */
+  dismissUpdateBanner: () => void;
+  clearError: () => void;
+  /** Tests only: reset to initial. */
+  reset: () => void;
+};
+
+const initial: Pick<ServiceWorkerStore, "phase" | "error"> = {
+  phase: "idle",
+  error: null,
+};
+
+export const useServiceWorkerStore = create<ServiceWorkerStore>((set, get) => ({
+  ...initial,
+
+  setPhase: (phase) => set({ phase }),
+
+  setError: (message) => {
+    if (message) {
+      set({ error: message, phase: "error" });
+      return;
+    }
+    set((s) => ({
+      error: null,
+      phase: s.phase === "error" ? "ready" : s.phase,
+    }));
+  },
+
+  setUpdateAvailable: () => {
+    if (get().phase === "error") return;
+    set({ phase: "update_available", error: null });
+  },
+
+  dismissUpdateBanner: () => {
+    set({ phase: "ready" });
+  },
+
+  clearError: () => {
+    set((s) => ({
+      error: null,
+      phase: s.phase === "error" ? "idle" : s.phase,
+    }));
+  },
+
+  reset: () => set({ ...initial }),
+}));

--- a/frontend/src/utils/sw-register.test.ts
+++ b/frontend/src/utils/sw-register.test.ts
@@ -1,0 +1,160 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { useServiceWorkerStore } from "../store/serviceWorkerStore";
+import {
+  __resetServiceWorkerTestStateForTests,
+  __setLastRegistrationForTests,
+  applyServiceWorkerUpdate,
+  registerServiceWorker,
+  SW_EVENT_ERROR,
+  SW_EVENT_REGISTERED,
+  SW_EVENT_UPDATE_AVAILABLE,
+} from "./sw-register";
+
+describe("registerServiceWorker", () => {
+  beforeEach(() => {
+    useServiceWorkerStore.getState().reset();
+    __resetServiceWorkerTestStateForTests();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    useServiceWorkerStore.getState().reset();
+    __resetServiceWorkerTestStateForTests();
+  });
+
+  it("sets unsupported when serviceWorker is missing", async () => {
+    vi.stubGlobal("navigator", {});
+    await registerServiceWorker();
+    expect(useServiceWorkerStore.getState().phase).toBe("unsupported");
+  });
+
+  it("emits registered and sets ready on success", async () => {
+    const onUpdateFound = vi.fn();
+    const mockReg = {
+      installing: null,
+      waiting: null,
+      addEventListener: (ev: string, fn: () => void) => {
+        if (ev === "updatefound") (mockReg as { _u?: () => void })._u = fn;
+      },
+      update: vi.fn().mockResolvedValue(undefined),
+    } as ServiceWorkerRegistration;
+
+    const register = vi.fn().mockResolvedValue(mockReg);
+    const addEventListener = vi.fn();
+    vi.stubGlobal("navigator", {
+      serviceWorker: { register, addEventListener },
+    });
+
+    const onRegistered = vi.fn();
+    window.addEventListener(SW_EVENT_REGISTERED, onRegistered);
+    const onError = vi.fn();
+    window.addEventListener(SW_EVENT_ERROR, onError);
+
+    await registerServiceWorker();
+
+    expect(register).toHaveBeenCalledWith(
+      "/sw.js",
+      expect.objectContaining({ updateViaCache: "none" }),
+    );
+    expect(useServiceWorkerStore.getState().phase).toBe("ready");
+    expect(onRegistered).toHaveBeenCalled();
+    const evt = onRegistered.mock.calls[0][0] as CustomEvent<{
+      registration: ServiceWorkerRegistration;
+    }>;
+    expect(evt.detail?.registration).toBe(mockReg);
+    expect(onError).not.toHaveBeenCalled();
+    window.removeEventListener(SW_EVENT_REGISTERED, onRegistered);
+    window.removeEventListener(SW_EVENT_ERROR, onError);
+  });
+
+  it("emits error and sets store on register failure", async () => {
+    const register = vi
+      .fn()
+      .mockRejectedValue(new Error("network or SW script missing"));
+    vi.stubGlobal("navigator", {
+      serviceWorker: { register, addEventListener: vi.fn() },
+    });
+    const onError = vi.fn();
+    window.addEventListener(SW_EVENT_ERROR, onError);
+
+    await registerServiceWorker();
+
+    expect(useServiceWorkerStore.getState().phase).toBe("error");
+    expect(useServiceWorkerStore.getState().error).toBe(
+      "network or SW script missing",
+    );
+    expect(onError).toHaveBeenCalled();
+    const fe = onError.mock.calls[0][0] as CustomEvent<{ message: string }>;
+    expect(fe.detail.message).toBe("network or SW script missing");
+    window.removeEventListener(SW_EVENT_ERROR, onError);
+  });
+
+  it("emits update available when a waiting worker exists and controller is active", async () => {
+    const mockReg = {
+      installing: null,
+      waiting: { postMessage: vi.fn() },
+      addEventListener: vi.fn(),
+      update: vi.fn().mockResolvedValue(undefined),
+    } as unknown as ServiceWorkerRegistration;
+
+    const register = vi.fn().mockResolvedValue(mockReg);
+    vi.stubGlobal("navigator", {
+      serviceWorker: { register, controller: {}, addEventListener: vi.fn() },
+    });
+
+    const onUpdate = vi.fn();
+    window.addEventListener(SW_EVENT_UPDATE_AVAILABLE, onUpdate);
+
+    await registerServiceWorker();
+
+    expect(onUpdate).toHaveBeenCalled();
+    expect(useServiceWorkerStore.getState().phase).toBe("update_available");
+    window.removeEventListener(SW_EVENT_UPDATE_AVAILABLE, onUpdate);
+  });
+
+  it("applyServiceWorkerUpdate posts SKIP_WAITING to waiting worker", () => {
+    const postMessage = vi.fn();
+    const mockReg = { waiting: { postMessage } } as unknown as ServiceWorkerRegistration;
+    __setLastRegistrationForTests(mockReg);
+    const addListener = vi.fn();
+    const removeListener = vi.fn();
+    const reload = vi.fn();
+    vi.stubGlobal("location", { ...location, reload });
+    vi.stubGlobal("navigator", {
+      serviceWorker: {
+        addEventListener: addListener,
+        removeEventListener: removeListener,
+        controller: {},
+      },
+    });
+
+    applyServiceWorkerUpdate();
+
+    expect(postMessage).toHaveBeenCalledWith({ type: "SKIP_WAITING" });
+    const handler = addListener.mock.calls.find(
+      (c) => c[0] === "controllerchange",
+    )?.[1] as (() => void) | undefined;
+    expect(typeof handler).toBe("function");
+    handler!();
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("applyServiceWorkerUpdate reloads immediately when there is no waiting worker", () => {
+    __setLastRegistrationForTests(
+      { waiting: null } as ServiceWorkerRegistration,
+    );
+    const reload = vi.fn();
+    vi.stubGlobal("location", { ...location, reload });
+
+    applyServiceWorkerUpdate();
+
+    expect(reload).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/utils/sw-register.ts
+++ b/frontend/src/utils/sw-register.ts
@@ -1,10 +1,169 @@
-export const registerServiceWorker = async () => {
-  if ('serviceWorker' in navigator) {
-    try {
-      const registration = await navigator.serviceWorker.register('/sw.js');
-      console.log('Service Worker registered:', registration);
-    } catch (error) {
-      console.error('SW registration failed:', error);
-    }
+import { useServiceWorkerStore } from "../store/serviceWorkerStore";
+
+/** Fired after successful registration (detail: `{ registration }`). */
+export const SW_EVENT_REGISTERED = "stellarsplit:sw-registered";
+/** Fired when a new service worker is installed and the page should prompt to reload. */
+export const SW_EVENT_UPDATE_AVAILABLE = "stellarsplit:sw-update-available";
+/** Fired on registration or lifecycle failure (detail: `{ message: string, cause?: unknown }`). */
+export const SW_EVENT_ERROR = "stellarsplit:sw-error";
+
+const SW_PATH = "/sw.js";
+
+let lastRegistration: ServiceWorkerRegistration | null = null;
+
+/**
+ * Fires when a new service worker is installed and an older one is still in control
+ * (typical: new build waiting to activate).
+ */
+function emitUpdateAvailable() {
+  useServiceWorkerStore.getState().setUpdateAvailable();
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(SW_EVENT_UPDATE_AVAILABLE, { detail: {} }),
+    );
   }
-};
+}
+
+function emitRegistered(reg: ServiceWorkerRegistration) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(SW_EVENT_REGISTERED, { detail: { registration: reg } }),
+    );
+  }
+}
+
+function emitError(message: string, cause?: unknown) {
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(
+      new CustomEvent(SW_EVENT_ERROR, { detail: { message, cause } }),
+    );
+  }
+}
+
+function notifyIfUpdateAvailable(reg: ServiceWorkerRegistration) {
+  if (reg.waiting && navigator.serviceWorker.controller) {
+    emitUpdateAvailable();
+  }
+}
+
+function attachToInstallingWorker(
+  reg: ServiceWorkerRegistration,
+  worker: ServiceWorker | null,
+) {
+  if (!worker) return;
+  const onState = () => {
+    if (worker.state === "installed" && navigator.serviceWorker.controller) {
+      emitUpdateAvailable();
+    }
+  };
+  worker.addEventListener("statechange", onState);
+  if (worker.state === "installed" && navigator.serviceWorker.controller) {
+    emitUpdateAvailable();
+  }
+}
+
+function watchRegistration(reg: ServiceWorkerRegistration) {
+  reg.addEventListener("updatefound", () => {
+    attachToInstallingWorker(reg, reg.installing);
+  });
+  if (reg.installing) {
+    attachToInstallingWorker(reg, reg.installing);
+  }
+  notifyIfUpdateAvailable(reg);
+}
+
+/**
+ * Call after `navigator` is available (e.g. from `main.tsx`).
+ * Drives `useServiceWorkerStore` (phase, error) and listens for new SW versions.
+ */
+export async function registerServiceWorker(): Promise<void> {
+  const store = useServiceWorkerStore.getState();
+  if (!("serviceWorker" in navigator)) {
+    store.setPhase("unsupported");
+    return;
+  }
+
+  store.setPhase("registering");
+  store.setError(null);
+  lastRegistration = null;
+
+  try {
+    const reg = await navigator.serviceWorker.register(SW_PATH, {
+      updateViaCache: "none",
+    });
+    lastRegistration = reg;
+    store.setPhase("ready");
+    watchRegistration(reg);
+    emitRegistered(reg);
+
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && reg) {
+        void reg.update();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisible);
+  } catch (err) {
+    const message =
+      err instanceof Error
+        ? err.message
+        : "Service worker registration failed";
+    store.setError(message);
+    emitError(message, err);
+  }
+}
+
+/**
+ * Activate a waiting service worker, if any, then reload when the controller changes.
+ * If there is no waiting worker, perform a full reload to pick up app shell changes.
+ */
+export function applyServiceWorkerUpdate(): void {
+  const reg = lastRegistration;
+  if (reg?.waiting) {
+    const onControllerChange = () => {
+      navigator.serviceWorker.removeEventListener(
+        "controllerchange",
+        onControllerChange,
+      );
+      window.location.reload();
+    };
+    navigator.serviceWorker.addEventListener("controllerchange", onControllerChange);
+    reg.waiting.postMessage({ type: "SKIP_WAITING" });
+    return;
+  }
+  window.location.reload();
+}
+
+/**
+ * Clear all caches, unregister the service worker, and reload (stale-asset / recovery path).
+ */
+export async function forceRefreshWithCacheClear(): Promise<void> {
+  try {
+    if ("caches" in globalThis) {
+      const names = await caches.keys();
+      await Promise.all(names.map((name) => caches.delete(name)));
+    }
+  } catch {
+    /* ignore */
+  }
+  try {
+    const r = lastRegistration ?? (await navigator.serviceWorker.getRegistration());
+    if (r) {
+      await r.unregister();
+    }
+  } catch {
+    /* ignore */
+  }
+  lastRegistration = null;
+  window.location.reload();
+}
+
+export function __resetServiceWorkerTestStateForTests() {
+  lastRegistration = null;
+}
+
+/** @internal Test-only: assign `lastRegistration` for apply / force-refresh tests. */
+export function __setLastRegistrationForTests(
+  reg: ServiceWorkerRegistration | null,
+) {
+  lastRegistration = reg;
+}


### PR DESCRIPTION
closes #360

## Summary
Service worker registration is no longer “console only.” The app now tracks registration and update state in a small Zustand store, surfaces a new version flow with explicit reload and full refresh (clear cache), and shows a recoverable error state with try again and dismiss. Registration runs from main.tsx once; App.tsx no longer duplicates it.

## What changed
serviceWorkerStore.ts – Phases: idle → registering → ready / update_available / error / unsupported; helpers for errors, dismissing the update bar, and test reset.
sw-register.ts – Register /sw.js with updateViaCache: "none"; listen for updatefound and installing statechange; recheck on visibilitychange; optional CustomEvents (stellarsplit:sw-registered, stellarsplit:sw-update-available, stellarsplit:sw-error) for extras/telemetry; applyServiceWorkerUpdate() (waiting worker + controllerchange reload, or plain reload); forceRefreshWithCacheClear() (caches + unregister + reload).
InstallPrompt.tsx – Themed update + error cards (plus existing install CTA when beforeinstallprompt is available); data-testid="pwa-floating-cta", role="status" / role="alert".
main.tsx – void registerServiceWorker(); render <InstallPrompt /> with the app shell.
Tests – serviceWorkerStore.test.ts, sw-register.test.ts, InstallPrompt.test.tsx (success, update-available, failure, and button wiring to reload / full refresh / retry).
## How to test
Prod-like: Deploy or run a build; after a new deploy, the update banner should appear when a new service worker is waiting; use Reload to update and Full refresh (clear cache).
Automated: cd frontend && npm run test -- --run src/store/serviceWorkerStore.test.ts src/utils/sw-register.test.ts src/components/InstallPrompt.test.tsx
