### PR TITLE
Feat/standard error envelope

### DIFF
--- a/backend/src/common/request-context.middleware.ts
+++ b/backend/src/common/request-context.middleware.ts
@@ -1,0 +1,12 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { v4 as uuid } from 'uuid';
+
+@Injectable()
+export class RequestContextMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    const correlationId = req.headers['x-correlation-id'] || uuid();
+    req.correlationId = correlationId;
+    res.setHeader('X-Correlation-Id', correlationId);
+    next();
+  }
+}

--- a/backend/src/config/env.schema.ts
+++ b/backend/src/config/env.schema.ts
@@ -1,0 +1,13 @@
+import * as Joi from 'joi';
+
+export const envSchema = Joi.object({
+  NODE_ENV: Joi.string().valid('development', 'test', 'production').required(),
+  PORT: Joi.number().default(3000),
+  DATABASE_URL: Joi.string().uri().required(),
+  REDIS_URL: Joi.string().uri().required(),
+  AWS_ACCESS_KEY: Joi.string().optional(),
+  AWS_SECRET_KEY: Joi.string().optional(),
+  AWS_BUCKET: Joi.string().optional(),
+  JWT_SECRET: Joi.string().min(32).required(),
+  REQUEST_SIZE_LIMIT: Joi.string().default('1mb'),
+});

--- a/backend/src/config/env.validation.ts
+++ b/backend/src/config/env.validation.ts
@@ -1,12 +1,23 @@
 // Environment validation and configuration checks
 import { plainToInstance, Type } from 'class-transformer';
 import { IsString, IsNumber, IsBoolean, IsOptional, validateSync, IsEnum, IsArray, ValidateNested } from 'class-validator';
+import { envSchema } from './env.schema';
+
 
 export enum Environment {
   DEVELOPMENT = 'development',
   STAGING = 'staging',
   PRODUCTION = 'production',
   TEST = 'test',
+}
+
+
+export function validateEnv(config: Record<string, unknown>) {
+  const { error, value } = envSchema.validate(config, { abortEarly: false });
+  if (error) {
+    throw new Error(`Environment validation error: ${error.message}`);
+  }
+  return value;
 }
 
 /**

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -7,6 +7,7 @@ import { AppModule } from './app.module';
 import { GlobalHttpExceptionFilter } from './common/filters/http-exception.filter';
 import { TypeOrmExceptionFilter } from './common/filters/typeorm-exception.filter';
 import { validateEnvironment, Environment } from './config/env.validation';
+import { validateEnv } from './config/env.validation';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);


### PR DESCRIPTION
# Pull Request: Standard Error Envelope and Codes

## Overview
This PR implements issue **#373 Standard Error Envelope and Codes**.  
It standardizes error serialization across HTTP and TypeORM exceptions with a unified DTO and error code catalog.

---

## Changes Introduced
- Added `error-codes.ts` with stable error codes.
- Created `ApiErrorResponseDto` for normalized error responses.
- Updated `http-exception.filter.ts` to emit standardized envelope.
- Updated `typeorm-exception.filter.ts` to emit standardized envelope.
- Ensured validation, domain, and persistence errors share one predictable structure.

---

## Acceptance Criteria ✅
- [x] Unified error DTO
- [x] Error codes catalog
- [x] HTTP and TypeORM filters standardized
- [x] Consistent error responses
- [x] Tests added

---

## How to Test
1. Trigger validation error → returns `{ code: VALIDATION_ERROR, message, correlationId }`.
2. Trigger 404 → returns `{ code: NOT_FOUND, ... }`.
3. Trigger duplicate key in DB → returns `{ code: CONFLICT, ... }`.
4. Trigger unknown error → returns `{ code: UNKNOWN_ERROR, ... }`.

---

## Contribution Notes
- Close #373