### PR TITLE
feat: Add duplicate name collision protection for split templates

### DIFF
--- a/contracts/split-template/src/lib.rs
+++ b/contracts/split-template/src/lib.rs
@@ -10,6 +10,7 @@ use soroban_sdk::{contract, contractimpl, Address, Env, String, Vec};
 
 mod events;
 mod id;
+mod name_index;
 mod storage;
 mod types;
 mod utils;
@@ -65,6 +66,11 @@ impl SplitTemplateContract {
         // Validate shares based on split type
         Self::validate_shares(&env, split_type, &participants)?;
 
+        // Check for duplicate name for this creator
+        if name_index::has_template_with_name(&env, &creator, &name) {
+            return Err(Error::DuplicateName);
+        }
+
         // Generate deterministic template ID from creator + name + ledger time
         let template_id = Self::generate_template_id(&env, &creator, &name);
 
@@ -80,6 +86,9 @@ impl SplitTemplateContract {
 
         // Store the template
         storage::store_template(&env, &template);
+
+        // Store name mapping to prevent duplicates
+        name_index::store_name_mapping(&env, &creator, &template.name, template_id.clone());
 
         // Add to creator's index for efficient lookup
         storage::add_to_creator_index(&env, &creator, template_id.clone());
@@ -166,6 +175,20 @@ impl SplitTemplateContract {
     /// Useful for off-chain tooling to detect contract upgrades.
     pub fn get_template_version(_env: Env) -> u32 {
         CURRENT_TEMPLATE_VERSION
+    }
+
+    /// Get a template by creator and name.
+    ///
+    /// # Arguments
+    /// * `env` - The Soroban environment
+    /// * `creator` - The address of the template creator
+    /// * `name` - The human-readable name of the template
+    ///
+    /// # Returns
+    /// The template if found, or an error
+    pub fn get_template_by_name(env: Env, creator: Address, name: String) -> Result<Template, Error> {
+        let template_id = name_index::get_template_id_by_name(&env, &creator, &name).ok_or(Error::TemplateNotFound)?;
+        storage::get_template(&env, &template_id).ok_or(Error::TemplateNotFound)
     }
 
     /// Check whether a given version is compatible with the current contract.

--- a/contracts/split-template/src/name_index.rs
+++ b/contracts/split-template/src/name_index.rs
@@ -1,0 +1,47 @@
+//! # Name Index Module for Split Template Contract
+//!
+//! Tracks creator/name pairs to prevent duplicate template names per creator.
+//! Provides fast lookup to check for existing templates with the same name.
+
+use soroban_sdk::{contracttype, Address, Env, String};
+
+// Storage key for creator + name mapping
+#[contracttype]
+#[derive(Clone)]
+pub struct CreatorNameKey {
+    pub creator: Address,
+    pub name: String,
+}
+
+// Time-to-live for persistent storage (about 1 year)
+const LEDGER_TTL_PERSISTENT: u32 = 31_536_000;
+
+/// Check if a template with the given creator and name already exists.
+pub fn has_template_with_name(env: &Env, creator: &Address, name: &String) -> bool {
+    let key = CreatorNameKey {
+        creator: creator.clone(),
+        name: name.clone(),
+    };
+    env.storage().persistent().has(&key)
+}
+
+/// Store the mapping from creator + name to template ID.
+pub fn store_name_mapping(env: &Env, creator: &Address, name: &String, template_id: String) {
+    let key = CreatorNameKey {
+        creator: creator.clone(),
+        name: name.clone(),
+    };
+    env.storage().persistent().set(&key, &template_id);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_PERSISTENT, LEDGER_TTL_PERSISTENT);
+}
+
+/// Get the template ID for a given creator and name, if it exists.
+pub fn get_template_id_by_name(env: &Env, creator: &Address, name: &String) -> Option<String> {
+    let key = CreatorNameKey {
+        creator: creator.clone(),
+        name: name.clone(),
+    };
+    env.storage().persistent().get(&key)
+}

--- a/contracts/split-template/src/test.rs
+++ b/contracts/split-template/src/test.rs
@@ -7,6 +7,7 @@ mod tests {
     };
 
     use crate::types::{Participant, SplitType};
+    use crate::Error;
     use crate::{SplitTemplateContract, SplitTemplateContractClient};
 
     fn setup() -> (Env, Address, SplitTemplateContractClient<'static>) {
@@ -263,6 +264,23 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
+    fn test_duplicate_name_rejection() {
+        let (env, creator, client) = setup();
+
+        let name = SorobanString::from_str(&env, "Duplicate Name Test");
+        let participants1 = create_equal_split_participants(&env, 2);
+        let participants2 = create_equal_split_participants(&env, 3); // Different participants
+
+        // Create first template
+        env.ledger().set_sequence(1000);
+        let _id1 = client.create_template(&creator, &name, &SplitType::Equal, &participants1);
+
+        // Attempt to create second template with same name should panic
+        let _ = client.create_template(&creator, &name, &SplitType::Equal, &participants2);
+    }
+
+    #[test]
     fn test_id_hex_format_validation() {
         let (env, creator, client) = setup();
 
@@ -302,6 +320,21 @@ mod tests {
         assert_eq!(template.name, name);
         assert_eq!(template.split_type, SplitType::Equal);
         assert_eq!(template.participants.len(), 3);
+    }
+
+    #[test]
+    fn test_get_template_by_name_success() {
+        let (env, creator, client) = setup();
+
+        let name = SorobanString::from_str(&env, "Named Template");
+        let participants = create_equal_split_participants(&env, 2);
+
+        let template_id = client.create_template(&creator, &name, &SplitType::Equal, &participants);
+
+        let template = client.get_template_by_name(&creator, &name);
+        assert_eq!(template.id, template_id);
+        assert_eq!(template.creator, creator);
+        assert_eq!(template.name, name);
     }
 
     #[test]

--- a/contracts/split-template/src/types.rs
+++ b/contracts/split-template/src/types.rs
@@ -57,4 +57,6 @@ pub enum Error {
     InvalidShares = 3,
     /// Template version is incompatible with the current contract
     IncompatibleVersion = 4,
+    /// A template with the same name already exists for this creator
+    DuplicateName = 5,
 }


### PR DESCRIPTION
closes #417 

## Problem
Creator indexing in the template contract does not protect against duplicate-name or duplicate-ID collisions gracefully.

## Solution
Implemented explicit duplicate-handling policy for template creation and retrieval by:
- Tracking creator/name pairs in a new name index
- Rejecting duplicate submissions cleanly with domain errors
- Maintaining collision-resistant IDs without ambiguity

## Changes Made

### Files Modified
- `contracts/split-template/src/types.rs`: Added `DuplicateName` error
- `contracts/split-template/src/lib.rs`: Added duplicate check in `create_template`, new `get_template_by_name` function
- `contracts/split-template/src/test.rs`: Added tests for duplicate rejection and name-based retrieval

### Files Created
- `contracts/split-template/src/name_index.rs`: New module for creator/name pair tracking

### Key Features
- **Duplicate Prevention**: Same creator cannot create multiple templates with identical names
- **Clean Error Handling**: Returns `Error::DuplicateName` for duplicate attempts
- **ID Collision Protection**: Prevents accidental overwrites by checking names first
- **Retrieval Support**: New `get_template_by_name(creator, name)` function
- **Backward Compatibility**: Existing creator index and functionality preserved

## Acceptance Criteria ✅
- [x] Duplicate template submissions are rejected cleanly
- [x] Tests for duplicate-name create attempts
- [x] Creator index integrity maintained
- [x] Domain errors exposed for duplicate submissions

## Testing
- Added `test_duplicate_name_rejection()` to verify duplicate attempts are rejected
- Added `test_get_template_by_name_success()` to test name-based retrieval
- All existing tests continue to pass

## Breaking Changes
None. This is a purely additive change that enhances validation without breaking existing functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added template lookup by creator and name, providing efficient direct access without scanning through all available templates.

* **Enhancements**
  * Template names are now enforced to be unique per creator. Creating a template with a duplicate name will fail with a clear error, preventing accidental overwrites or conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->