### PR TITLE
feat: create split detail repository to extract data composition logic

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -167,6 +167,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1779,6 +1780,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1822,6 +1824,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3629,8 +3632,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3778,6 +3780,7 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3788,6 +3791,7 @@
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3798,6 +3802,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3867,6 +3872,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4229,6 +4235,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4668,6 +4675,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5004,7 +5012,8 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -5328,8 +5337,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5685,6 +5693,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6613,6 +6622,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.28.4"
       },
@@ -7297,6 +7307,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -7853,7 +7864,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8370,7 +8380,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8386,7 +8395,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8450,6 +8458,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8459,6 +8468,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8548,6 +8558,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8662,7 +8673,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -8828,6 +8840,7 @@
       "integrity": "sha512-y9yUpfQvetAjiDLtNMf1hL9NXchIJgWt6zIKeoB+tCd3npX08Eqfzg60V9DhIGVMtQ0AlMkFw5xa+AQ37zxnAA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -9932,6 +9945,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10158,6 +10172,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -10685,6 +10700,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -10752,6 +10768,7 @@
       "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11087,6 +11104,7 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.29.tgz",
       "integrity": "sha512-kHqDPdltoXH+X4w1lVmMtddE3Oeqq48nM40FD5ojTd8xYhQpzIDcfE2keMSU5bAgRPJBe225WTUdyUgj1DtbiQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -11118,6 +11136,7 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/pages/SplitView/SplitDetailPage.tsx
+++ b/frontend/src/pages/SplitView/SplitDetailPage.tsx
@@ -24,138 +24,13 @@ import {
     createActivityRecord,
     createItem,
     deleteItem,
-    fetchProfile,
-    fetchReceiptSignedUrl,
-    fetchSplitById,
-    fetchSplitReceipts,
-    fetchUserActivities,
     getApiErrorMessage,
     normalizeDecimal,
     submitSplitPayment,
     updateSplit,
-    type ApiActivityRecord,
-    type ApiProfile,
-    type ApiSplitParticipant,
 } from '../../utils/api-client';
-import { getStoredSplitParticipantDirectory } from '../../utils/session';
+import { splitDetailRepository } from '../../services/splitDetailRepository';
 
-function matchesCurrentUser(
-    participant: ApiSplitParticipant,
-    currentUserId: string | null,
-): boolean {
-    if (!currentUserId) {
-        return false;
-    }
-
-    return participant.walletAddress === currentUserId || participant.userId === currentUserId;
-}
-
-function shortId(value: string): string {
-    return `${value.slice(0, 6)}...${value.slice(-4)}`;
-}
-
-function resolveParticipantName(
-    participant: ApiSplitParticipant,
-    splitId: string,
-    currentUserId: string | null,
-    profileMap: Record<string, ApiProfile>,
-): string {
-    if (matchesCurrentUser(participant, currentUserId)) {
-        return 'You';
-    }
-
-    if (participant.walletAddress && profileMap[participant.walletAddress]?.displayName) {
-        return profileMap[participant.walletAddress].displayName ?? shortId(participant.walletAddress);
-    }
-
-    const storedDirectory = getStoredSplitParticipantDirectory(splitId);
-    if (storedDirectory[participant.userId]?.name) {
-        return storedDirectory[participant.userId].name;
-    }
-
-    if (participant.walletAddress) {
-        return shortId(participant.walletAddress);
-    }
-
-    return shortId(participant.userId);
-}
-
-function buildActivityMessage(
-    activity: ApiActivityRecord,
-    splitTitle: string,
-): ActivityFeedItem {
-    const metadataTitle =
-        typeof activity.metadata.title === 'string' ? activity.metadata.title : splitTitle;
-    const amount =
-        typeof activity.metadata.amount === 'number' || typeof activity.metadata.amount === 'string'
-            ? normalizeDecimal(activity.metadata.amount as number | string)
-            : 0;
-    const actor =
-        typeof activity.metadata.actorName === 'string'
-            ? activity.metadata.actorName
-            : 'Someone';
-
-    switch (activity.activityType) {
-        case 'split_created':
-            return {
-                id: activity.id,
-                type: 'custom',
-                userName: actor,
-                message: `created ${metadataTitle}`,
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-        case 'payment_made':
-            return {
-                id: activity.id,
-                type: 'payment-status',
-                userName: actor,
-                message: `paid ${amount > 0 ? amount.toFixed(2) : ''} toward ${metadataTitle}`.trim(),
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-        case 'payment_received':
-            return {
-                id: activity.id,
-                type: 'payment-status',
-                userName: actor,
-                message: `received a payment for ${metadataTitle}`,
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-        case 'split_completed':
-            return {
-                id: activity.id,
-                type: 'payment-status',
-                userName: actor,
-                message: `marked ${metadataTitle} as completed`,
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-        case 'split_edited':
-            return {
-                id: activity.id,
-                type: 'item-updated',
-                userName: actor,
-                message: `updated ${metadataTitle}`,
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-        default:
-            return {
-                id: activity.id,
-                type: 'custom',
-                userName: actor,
-                message: `added an update to ${metadataTitle}`,
-                timestamp: activity.createdAt,
-                splitId: activity.splitId,
-            };
-    }
-}
-
-function roundCurrency(value: number): number {
-    return Math.round(value * 100) / 100;
-}
 
 export const SplitDetailPage = () => {
     const { t } = useTranslation();
@@ -195,87 +70,12 @@ export const SplitDetailPage = () => {
         setIsNotFound(false);
 
         try {
-            const splitRecord = await fetchSplitById(splitId);
-            const walletAddresses = Array.from(
-                new Set(
-                    [splitRecord.creatorWalletAddress, ...splitRecord.participants.map((participant) => participant.walletAddress)]
-                        .filter((walletAddress): walletAddress is string => Boolean(walletAddress)),
-                ),
-            );
-
-            const [profiles, latestReceiptUrl, activitiesResponse] = await Promise.all([
-                Promise.allSettled(walletAddresses.map((walletAddress) => fetchProfile(walletAddress))),
-                activeUserId
-                    ? fetchSplitReceipts(splitId)
-                        .then(async (receipts) => {
-                            const latestReceipt = [...receipts].sort(
-                                (left, right) =>
-                                    new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
-                            )[0];
-                            if (!latestReceipt) {
-                                return null;
-                            }
-
-                            return fetchReceiptSignedUrl(latestReceipt.id);
-                        })
-                        .catch(() => null)
-                    : Promise.resolve(null),
-                activeUserId
-                    ? fetchUserActivities(activeUserId, { splitId, limit: 20 }).catch(() => null)
-                    : Promise.resolve(null),
-            ]);
-
-            const profileMap = profiles.reduce<Record<string, ApiProfile>>((map, result, index) => {
-                if (result.status === 'fulfilled' && result.value) {
-                    map[walletAddresses[index]] = result.value;
-                }
-                return map;
-            }, {});
-
-            const participants: Participant[] = splitRecord.participants.map((participant) => {
-                const totalOwed = normalizeDecimal(participant.amountOwed);
-                const amountPaid = normalizeDecimal(participant.amountPaid);
-                return {
-                    id: participant.id,
-                    userId: participant.userId,
-                    name: resolveParticipantName(participant, splitRecord.id, activeUserId, profileMap),
-                    amountOwed: totalOwed,
-                    amountPaid,
-                    amountDue: Math.max(0, roundCurrency(totalOwed - amountPaid)),
-                    status: participant.status,
-                    isCurrentUser: matchesCurrentUser(participant, activeUserId),
-                    walletAddress: participant.walletAddress ?? undefined,
-                };
+            const viewModel = await splitDetailRepository.getSplitDetail(splitId, {
+                currentUserId: activeUserId,
             });
 
-            const nextSplit: Split = {
-                id: splitRecord.id,
-                title: splitRecord.description?.trim() || `Split ${splitRecord.id.slice(0, 8)}`,
-                totalAmount: normalizeDecimal(splitRecord.totalAmount),
-                amountPaid: normalizeDecimal(splitRecord.amountPaid),
-                currency: splitRecord.preferredCurrency || 'XLM',
-                date: splitRecord.createdAt,
-                status: splitRecord.status,
-                receiptUrl: latestReceiptUrl ?? undefined,
-                creatorWalletAddress: splitRecord.creatorWalletAddress ?? undefined,
-                preferredCurrency: splitRecord.preferredCurrency ?? undefined,
-                participants,
-                items: (splitRecord.items ?? []).map((item) => ({
-                    id: item.id,
-                    name: item.name,
-                    price: normalizeDecimal(item.totalPrice),
-                    quantity: item.quantity,
-                    unitPrice: normalizeDecimal(item.unitPrice),
-                    assignedToIds: item.assignedToIds,
-                })),
-            };
-
-            setSplit(nextSplit);
-            setActivityItems(
-                (activitiesResponse?.data ?? []).map((activity) =>
-                    buildActivityMessage(activity, nextSplit.title),
-                ),
-            );
+            setSplit(viewModel.split);
+            setActivityItems(viewModel.activityItems);
         } catch (error) {
             const message = getApiErrorMessage(error);
             if (message.toLowerCase().includes('not found')) {

--- a/frontend/src/services/splitDetailRepository.test.ts
+++ b/frontend/src/services/splitDetailRepository.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { splitDetailRepository } from './splitDetailRepository';
+import {
+    fetchProfile,
+    fetchReceiptSignedUrl,
+    fetchSplitById,
+    fetchSplitReceipts,
+    fetchUserActivities,
+} from '../utils/api-client';
+import { getStoredSplitParticipantDirectory } from '../utils/session';
+
+vi.mock('../utils/api-client');
+vi.mock('../utils/session');
+
+describe('splitDetailRepository', () => {
+    const mockSplitId = 'split-123';
+    const mockCurrentUserId = 'user-abc';
+    const mockWalletAddress = 'wallet-xyz';
+
+    const mockSplitRecord = {
+        id: mockSplitId,
+        totalAmount: '100.00',
+        amountPaid: '50.00',
+        status: 'active' as const,
+        description: 'Test Split',
+        preferredCurrency: 'USD',
+        creatorWalletAddress: mockWalletAddress,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+        participants: [
+            {
+                id: 'participant-1',
+                userId: 'user-abc',
+                amountOwed: '50.00',
+                amountPaid: '25.00',
+                status: 'partial' as const,
+                walletAddress: mockWalletAddress,
+            },
+            {
+                id: 'participant-2',
+                userId: 'user-def',
+                amountOwed: '50.00',
+                amountPaid: '25.00',
+                status: 'partial' as const,
+                walletAddress: 'wallet-def',
+            },
+        ],
+        items: [],
+    };
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.mocked(getStoredSplitParticipantDirectory).mockReturnValue({});
+    });
+
+    it('fetches and composes split detail with all data', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue({
+            walletAddress: mockWalletAddress,
+            displayName: 'Test User',
+            avatarUrl: null,
+            preferredCurrency: 'USD',
+        });
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([
+            {
+                id: 'receipt-1',
+                splitId: mockSplitId,
+                uploadedBy: mockCurrentUserId,
+                originalFilename: 'receipt.jpg',
+                storagePath: '/path/to/receipt.jpg',
+                fileSize: 1024,
+                mimeType: 'image/jpeg',
+                ocrProcessed: false,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ]);
+        vi.mocked(fetchReceiptSignedUrl).mockResolvedValue('https://example.com/receipt.jpg');
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.id).toBe(mockSplitId);
+        expect(result.split.title).toBe('Test Split');
+        expect(result.split.participants).toHaveLength(2);
+        expect(result.activityItems).toEqual([]);
+    });
+
+    it('handles missing profiles gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants[0].name).toBe('You');
+        expect(result.split.participants[1].name).toContain('...');
+    });
+
+    it('handles profile fetch failures gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockRejectedValue(new Error('Profile fetch failed'));
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants).toHaveLength(2);
+        expect(result.split.participants[0].name).toBe('You');
+    });
+
+    it('handles missing receipts gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.receiptUrl).toBeUndefined();
+    });
+
+    it('handles receipt fetch failures gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockRejectedValue(new Error('Receipt fetch failed'));
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.receiptUrl).toBeUndefined();
+    });
+
+    it('handles signed URL fetch failures gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([
+            {
+                id: 'receipt-1',
+                splitId: mockSplitId,
+                uploadedBy: mockCurrentUserId,
+                originalFilename: 'receipt.jpg',
+                storagePath: '/path/to/receipt.jpg',
+                fileSize: 1024,
+                mimeType: 'image/jpeg',
+                ocrProcessed: false,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ]);
+        vi.mocked(fetchReceiptSignedUrl).mockRejectedValue(new Error('Signed URL fetch failed'));
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.receiptUrl).toBeUndefined();
+    });
+
+    it('handles activity fetch failures gracefully', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockRejectedValue(new Error('Activity fetch failed'));
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.activityItems).toEqual([]);
+    });
+
+    it('resolves participant names from session directory as fallback', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+        vi.mocked(getStoredSplitParticipantDirectory).mockReturnValue({
+            'user-def': { name: 'Fallback Name' },
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants[1].name).toBe('Fallback Name');
+    });
+
+    it('uses wallet address short ID when no profile or session data exists', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants[1].name).toBe('wallet...-def');
+    });
+
+    it('returns null for receipt URL when no current user', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: null,
+        });
+
+        expect(result.split.receiptUrl).toBeUndefined();
+        expect(result.activityItems).toEqual([]);
+    });
+
+    it('builds activity messages correctly', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue({
+            walletAddress: mockWalletAddress,
+            displayName: 'Test User',
+            avatarUrl: null,
+            preferredCurrency: 'USD',
+        });
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [
+                {
+                    id: 'activity-1',
+                    userId: mockCurrentUserId,
+                    activityType: 'payment_made',
+                    splitId: mockSplitId,
+                    metadata: {
+                        actorName: 'Test User',
+                        title: 'Test Split',
+                        amount: 25.50,
+                    },
+                    isRead: false,
+                    createdAt: '2026-01-01T00:00:00.000Z',
+                },
+            ],
+            total: 1,
+            page: 1,
+            limit: 20,
+            totalPages: 1,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.activityItems).toHaveLength(1);
+        expect(result.activityItems[0].type).toBe('payment-status');
+        expect(result.activityItems[0].message).toContain('paid');
+        expect(result.activityItems[0].message).toContain('Test Split');
+    });
+
+    it('maps participant structure correctly', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue({
+            walletAddress: mockWalletAddress,
+            displayName: 'Test User',
+            avatarUrl: null,
+            preferredCurrency: 'USD',
+        });
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants).toHaveLength(2);
+        const firstParticipant = result.split.participants[0];
+        expect(firstParticipant).toBeDefined();
+        expect(firstParticipant.id).toBe('participant-1');
+        expect(firstParticipant.userId).toBe('user-abc');
+        expect(firstParticipant.name).toBeDefined();
+        expect(firstParticipant.status).toBeDefined();
+    });
+
+    it('identifies current user correctly', async () => {
+        vi.mocked(fetchSplitById).mockResolvedValue(mockSplitRecord);
+        vi.mocked(fetchProfile).mockResolvedValue(null);
+        vi.mocked(fetchSplitReceipts).mockResolvedValue([]);
+        vi.mocked(fetchUserActivities).mockResolvedValue({
+            data: [],
+            total: 0,
+            page: 1,
+            limit: 20,
+            totalPages: 0,
+            hasMore: false,
+            unreadCount: 0,
+        });
+
+        const result = await splitDetailRepository.getSplitDetail(mockSplitId, {
+            currentUserId: mockCurrentUserId,
+        });
+
+        expect(result.split.participants[0].isCurrentUser).toBe(true);
+        expect(result.split.participants[1].isCurrentUser).toBe(false);
+    });
+});

--- a/frontend/src/services/splitDetailRepository.ts
+++ b/frontend/src/services/splitDetailRepository.ts
@@ -1,0 +1,270 @@
+import type { Participant, Split } from '../types';
+import type { ActivityFeedItem } from '../components/Collaboration';
+import {
+    fetchProfile,
+    fetchReceiptSignedUrl,
+    fetchSplitById,
+    fetchSplitReceipts,
+    fetchUserActivities,
+    normalizeDecimal,
+    type ApiActivityRecord,
+    type ApiProfile,
+    type ApiSplitParticipant,
+} from '../utils/api-client';
+import { getStoredSplitParticipantDirectory } from '../utils/session';
+
+export interface SplitDetailViewModel {
+    split: Split;
+    activityItems: ActivityFeedItem[];
+}
+
+export interface SplitDetailRepositoryOptions {
+    currentUserId: string | null;
+}
+
+class SplitDetailRepository {
+    private shortId(value: string): string {
+        return `${value.slice(0, 6)}...${value.slice(-4)}`;
+    }
+
+    private matchesCurrentUser(
+        participant: ApiSplitParticipant,
+        currentUserId: string | null,
+    ): boolean {
+        if (!currentUserId) {
+            return false;
+        }
+
+        return participant.walletAddress === currentUserId || participant.userId === currentUserId;
+    }
+
+    private resolveParticipantName(
+        participant: ApiSplitParticipant,
+        splitId: string,
+        currentUserId: string | null,
+        profileMap: Record<string, ApiProfile>,
+    ): string {
+        if (this.matchesCurrentUser(participant, currentUserId)) {
+            return 'You';
+        }
+
+        if (participant.walletAddress && profileMap[participant.walletAddress]?.displayName) {
+            return profileMap[participant.walletAddress].displayName ?? this.shortId(participant.walletAddress);
+        }
+
+        const storedDirectory = getStoredSplitParticipantDirectory(splitId);
+        if (storedDirectory[participant.userId]?.name) {
+            return storedDirectory[participant.userId].name;
+        }
+
+        if (participant.walletAddress) {
+            return this.shortId(participant.walletAddress);
+        }
+
+        return this.shortId(participant.userId);
+    }
+
+    private buildActivityMessage(
+        activity: ApiActivityRecord,
+        splitTitle: string,
+    ): ActivityFeedItem {
+        const metadataTitle =
+            typeof activity.metadata.title === 'string' ? activity.metadata.title : splitTitle;
+        const amount =
+            typeof activity.metadata.amount === 'number' || typeof activity.metadata.amount === 'string'
+                ? normalizeDecimal(activity.metadata.amount as number | string)
+                : 0;
+        const actor =
+            typeof activity.metadata.actorName === 'string'
+                ? activity.metadata.actorName
+                : 'Someone';
+
+        switch (activity.activityType) {
+            case 'split_created':
+                return {
+                    id: activity.id,
+                    type: 'custom',
+                    userName: actor,
+                    message: `created ${metadataTitle}`,
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+            case 'payment_made':
+                return {
+                    id: activity.id,
+                    type: 'payment-status',
+                    userName: actor,
+                    message: `paid ${amount > 0 ? amount.toFixed(2) : ''} toward ${metadataTitle}`.trim(),
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+            case 'payment_received':
+                return {
+                    id: activity.id,
+                    type: 'payment-status',
+                    userName: actor,
+                    message: `received a payment for ${metadataTitle}`,
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+            case 'split_completed':
+                return {
+                    id: activity.id,
+                    type: 'payment-status',
+                    userName: actor,
+                    message: `marked ${metadataTitle} as completed`,
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+            case 'split_edited':
+                return {
+                    id: activity.id,
+                    type: 'item-updated',
+                    userName: actor,
+                    message: `updated ${metadataTitle}`,
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+            default:
+                return {
+                    id: activity.id,
+                    type: 'custom',
+                    userName: actor,
+                    message: `added an update to ${metadataTitle}`,
+                    timestamp: activity.createdAt,
+                    splitId: activity.splitId,
+                };
+        }
+    }
+
+    private roundCurrency(value: number): number {
+        return Math.round(value * 100) / 100;
+    }
+
+    private async fetchProfiles(
+        walletAddresses: string[],
+    ): Promise<Record<string, ApiProfile>> {
+        const results = await Promise.allSettled(
+            walletAddresses.map((walletAddress) => fetchProfile(walletAddress)),
+        );
+
+        return results.reduce<Record<string, ApiProfile>>((map, result, index) => {
+            if (result.status === 'fulfilled' && result.value) {
+                map[walletAddresses[index]] = result.value;
+            }
+            return map;
+        }, {});
+    }
+
+    private async fetchLatestReceiptUrl(
+        splitId: string,
+        currentUserId: string | null,
+    ): Promise<string | null> {
+        if (!currentUserId) {
+            return null;
+        }
+
+        try {
+            const receipts = await fetchSplitReceipts(splitId);
+            const latestReceipt = [...receipts].sort(
+                (left, right) =>
+                    new Date(right.createdAt).getTime() - new Date(left.createdAt).getTime(),
+            )[0];
+
+            if (!latestReceipt) {
+                return null;
+            }
+
+            return await fetchReceiptSignedUrl(latestReceipt.id);
+        } catch {
+            return null;
+        }
+    }
+
+    private async fetchActivities(
+        currentUserId: string | null,
+        splitId: string,
+    ): Promise<ApiActivityRecord[] | null> {
+        if (!currentUserId) {
+            return null;
+        }
+
+        try {
+            const response = await fetchUserActivities(currentUserId, { splitId, limit: 20 });
+            return response.data;
+        } catch {
+            return null;
+        }
+    }
+
+    async getSplitDetail(
+        splitId: string,
+        options: SplitDetailRepositoryOptions,
+    ): Promise<SplitDetailViewModel> {
+        const { currentUserId } = options;
+
+        const splitRecord = await fetchSplitById(splitId);
+
+        const walletAddresses = Array.from(
+            new Set(
+                [splitRecord.creatorWalletAddress, ...splitRecord.participants.map((participant) => participant.walletAddress)]
+                    .filter((walletAddress): walletAddress is string => Boolean(walletAddress)),
+            ),
+        );
+
+        const [profileMap, latestReceiptUrl, activities] = await Promise.all([
+            this.fetchProfiles(walletAddresses),
+            this.fetchLatestReceiptUrl(splitId, currentUserId),
+            this.fetchActivities(currentUserId, splitId),
+        ]);
+
+        const participants: Participant[] = splitRecord.participants.map((participant) => {
+            const totalOwed = normalizeDecimal(participant.amountOwed);
+            const amountPaid = normalizeDecimal(participant.amountPaid);
+            return {
+                id: participant.id,
+                userId: participant.userId,
+                name: this.resolveParticipantName(participant, splitRecord.id, currentUserId, profileMap),
+                amountOwed: totalOwed,
+                amountPaid,
+                amountDue: Math.max(0, this.roundCurrency(totalOwed - amountPaid)),
+                status: participant.status,
+                isCurrentUser: this.matchesCurrentUser(participant, currentUserId),
+                walletAddress: participant.walletAddress ?? undefined,
+            };
+        });
+
+        const split: Split = {
+            id: splitRecord.id,
+            title: splitRecord.description?.trim() || `Split ${splitRecord.id.slice(0, 8)}`,
+            totalAmount: normalizeDecimal(splitRecord.totalAmount),
+            amountPaid: normalizeDecimal(splitRecord.amountPaid),
+            currency: splitRecord.preferredCurrency || 'XLM',
+            date: splitRecord.createdAt,
+            status: splitRecord.status,
+            receiptUrl: latestReceiptUrl ?? undefined,
+            creatorWalletAddress: splitRecord.creatorWalletAddress ?? undefined,
+            preferredCurrency: splitRecord.preferredCurrency ?? undefined,
+            participants,
+            items: (splitRecord.items ?? []).map((item) => ({
+                id: item.id,
+                name: item.name,
+                price: normalizeDecimal(item.totalPrice),
+                quantity: item.quantity,
+                unitPrice: normalizeDecimal(item.unitPrice),
+                assignedToIds: item.assignedToIds,
+            })),
+        };
+
+        const activityItems = (activities ?? []).map((activity) =>
+            this.buildActivityMessage(activity, split.title),
+        );
+
+        return {
+            split,
+            activityItems,
+        };
+    }
+}
+
+export const splitDetailRepository = new SplitDetailRepository();


### PR DESCRIPTION
closes #462 

- Create splitDetailRepository.ts with typed contract for split detail data composition
- Refactor SplitDetailPage.tsx to use the repository instead of inline Promise.allSettled
- Move profile hydration, receipt lookup, and activity mapping into repository
- Add comprehensive repository tests for edge cases (missing profiles, receipts, activity failures, participant-name resolution)
- Page now consumes one normalized view model from repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized internal split detail data retrieval and composition logic for improved code maintainability.

* **Tests**
  * Added comprehensive test coverage for split detail data processing, including participant name resolution, receipt URL retrieval, and activity feed composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->