### PR TITLE
Split calculator deep link route suppor

### DIFF
--- a/frontend/src/components/SplitCalculator/CalculationSummary.tsx
+++ b/frontend/src/components/SplitCalculator/CalculationSummary.tsx
@@ -8,6 +8,7 @@ interface CalculationSummaryProps {
   subtotal: number;
   currency: string;
   rounding: 'none' | 'up' | 'down' | 'nearest';
+  onExport?: () => void;
 }
 
 const CURRENCY_SYMBOLS: Record<string, string> = {
@@ -23,6 +24,7 @@ export function CalculationSummary({
   subtotal,
   currency,
   rounding,
+  onExport,
 }: CalculationSummaryProps) {
   const { t } = useTranslation();
   const currencySymbol = CURRENCY_SYMBOLS[currency] || '$';
@@ -161,6 +163,14 @@ export function CalculationSummary({
         >
           {t('calculator.copyToClipboard')}
         </button>
+        {onExport && (
+          <button
+            onClick={onExport}
+            className="px-4 py-2 text-sm font-medium text-white bg-[var(--color-primary)] rounded-lg hover:bg-[var(--color-primary-dark)] transition-colors"
+          >
+            {t('calculator.export')}
+          </button>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/SplitCalculator/SplitCalculator.spec.tsx
+++ b/frontend/src/components/SplitCalculator/SplitCalculator.spec.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { SplitCalculator } from './SplitCalculator';
+import { clearCalculatorTemplates, saveCalculatorTemplate } from '../../services/calculatorTemplateStore';
+
+describe('SplitCalculator', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearCalculatorTemplates();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    clearCalculatorTemplates();
+  });
+
+  it('applies a saved template and resets to the initial calculator state', () => {
+    saveCalculatorTemplate('Vacation', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 50, percentage: 50, items: [] },
+        { id: '2', name: 'Bob', amount: 50, percentage: 50, items: [] },
+      ],
+      items: [],
+      totalAmount: 100,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'EUR',
+      rounding: 'none',
+    });
+
+    render(<SplitCalculator />);
+
+    expect(screen.getByRole('button', { name: /Apply/i })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Apply/i }));
+
+    expect(screen.getByLabelText(/currency/i)).toHaveValue('EUR');
+
+    fireEvent.click(screen.getByRole('button', { name: /Reset/i }));
+
+    expect(screen.getByLabelText(/currency/i)).toHaveValue('USD');
+  });
+});

--- a/frontend/src/components/SplitCalculator/SplitCalculator.tsx
+++ b/frontend/src/components/SplitCalculator/SplitCalculator.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { Calculator, Download, Share2, Save, RefreshCw } from "lucide-react";
 import { EqualSplitCalc } from "./EqualSplitCalc";
@@ -6,6 +6,15 @@ import { ItemizedSplitCalc } from "./ItemizedSplitCalc";
 import { PercentageSplitCalc } from "./PercentageSplitCalc";
 import { CustomSplitCalc } from "./CustomSplitCalc";
 import { CalculationSummary } from "./CalculationSummary";
+import {
+  CalculatorTemplate,
+  DuplicateTemplateNameError,
+  deleteCalculatorTemplate,
+  getCalculatorTemplate,
+  listCalculatorTemplates,
+  saveCalculatorTemplate,
+} from "../../services/calculatorTemplateStore";
+import { exportSplitCalculation } from "../../utils/exportSplitCalculation";
 
 export type CalculatorType = "equal" | "itemized" | "percentage" | "custom";
 
@@ -61,9 +70,14 @@ export function SplitCalculator() {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<CalculatorType>("equal");
   const [state, setState] = useState<CalculatorState>(INITIAL_STATE);
-  const [, setSavedTemplates] = useState<
-    { name: string; state: CalculatorState }[]
-  >([]);
+  const [savedTemplates, setSavedTemplates] = useState<CalculatorTemplate[]>([]);
+  const [templateName, setTemplateName] = useState('');
+  const [templateError, setTemplateError] = useState<string | null>(null);
+  const [isSavingTemplate, setIsSavingTemplate] = useState(false);
+
+  useEffect(() => {
+    setSavedTemplates(listCalculatorTemplates());
+  }, []);
 
   const updateState = useCallback((updates: Partial<CalculatorState>) => {
     setState((prev) => ({ ...prev, ...updates }));
@@ -74,24 +88,59 @@ export function SplitCalculator() {
   };
 
   const handleExport = () => {
-    const summary = {
-      type: state.type,
-      participants: state.participants,
-      items: state.items,
-      subtotal: calculateSubtotal(),
-      currency: state.currency,
-      rounding: state.rounding,
-    };
+    exportSplitCalculation(
+      {
+        type: state.type,
+        participants: state.participants,
+        items: state.items,
+        subtotal: calculateSubtotal(),
+        currency: state.currency,
+        rounding: state.rounding,
+      },
+      `split-calculation-${Date.now()}.json`,
+    );
+  };
 
-    const blob = new Blob([JSON.stringify(summary, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `split-calculation-${Date.now()}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+  const handleSaveTemplate = () => {
+    setIsSavingTemplate((current) => !current);
+    setTemplateError(null);
+  };
+
+  const handleTemplateSaveSubmit = () => {
+    const normalizedName = templateName.trim();
+    if (!normalizedName) {
+      setTemplateError(t('calculator.templateNameRequired') || 'Enter a template name.');
+      return;
+    }
+
+    try {
+      const saved = saveCalculatorTemplate(normalizedName, state);
+      setSavedTemplates((prev) => [...prev, saved]);
+      setTemplateName('');
+      setTemplateError(null);
+      setIsSavingTemplate(false);
+    } catch (error) {
+      if (error instanceof DuplicateTemplateNameError) {
+        setTemplateError(t('calculator.templateDuplicateName') || 'A template with this name already exists.');
+      } else {
+        setTemplateError(t('calculator.saveTemplateError') || 'Unable to save template.');
+      }
+    }
+  };
+
+  const handleApplyTemplate = (name: string) => {
+    const template = getCalculatorTemplate(name);
+    if (!template) {
+      return;
+    }
+
+    setState({ ...template.state });
+    setActiveTab(template.state.type);
+  };
+
+  const handleDeleteTemplate = (name: string) => {
+    deleteCalculatorTemplate(name);
+    setSavedTemplates((prev) => prev.filter((item) => item.name !== name));
   };
 
   const handleShare = async () => {
@@ -118,13 +167,6 @@ export function SplitCalculator() {
       }
     } else {
       await navigator.clipboard.writeText(shareUrl);
-    }
-  };
-
-  const handleSaveTemplate = () => {
-    const name = prompt(t("calculator.templateName") || "Enter template name:");
-    if (name) {
-      setSavedTemplates((prev) => [...prev, { name, state: { ...state } }]);
     }
   };
 
@@ -301,6 +343,103 @@ export function SplitCalculator() {
         </div>
       </div>
 
+      {/* Saved Templates */}
+      <div className="mb-6 p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700">
+        <div className="flex flex-wrap items-center justify-between gap-3 mb-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {t('calculator.savedTemplates') || 'Saved Templates'}
+            </h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t('calculator.savedTemplatesSubtitle') || 'Capture your split configurations for reuse.'}
+            </p>
+          </div>
+          <button
+            onClick={handleSaveTemplate}
+            className="px-4 py-2 text-sm font-medium text-white bg-[var(--color-primary)] rounded-lg hover:bg-[var(--color-primary-dark)] transition-colors"
+            type="button"
+          >
+            {t('calculator.saveTemplate') || 'Save Template'}
+          </button>
+        </div>
+
+        {isSavingTemplate && (
+          <div className="mb-4 grid gap-3">
+            <input
+              value={templateName}
+              onChange={(event) => setTemplateName(event.target.value)}
+              placeholder={t('calculator.templateNamePlaceholder') || 'Template name'}
+              className="w-full px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              aria-label={t('calculator.templateNamePlaceholder') || 'Template name'}
+            />
+            {templateError && (
+              <p className="text-sm text-rose-600 dark:text-rose-400">{templateError}</p>
+            )}
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={handleTemplateSaveSubmit}
+                className="px-4 py-2 text-sm font-medium text-white bg-[var(--color-primary)] rounded-lg hover:bg-[var(--color-primary-dark)] transition-colors"
+                type="button"
+              >
+                {t('calculator.save') || 'Save'}
+              </button>
+              <button
+                onClick={() => {
+                  setIsSavingTemplate(false);
+                  setTemplateName('');
+                  setTemplateError(null);
+                }}
+                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 dark:text-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 transition-colors"
+                type="button"
+              >
+                {t('calculator.cancel') || 'Cancel'}
+              </button>
+            </div>
+          </div>
+        )}
+
+        {savedTemplates.length > 0 ? (
+          <div className="grid gap-3">
+            {savedTemplates.map((template) => (
+              <div
+                key={template.name}
+                className="flex flex-col gap-3 rounded-xl border border-gray-200 dark:border-gray-700 p-4 bg-gray-50 dark:bg-gray-900"
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="font-semibold text-gray-900 dark:text-gray-100">{template.name}</p>
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
+                      {t('calculator.lastUpdated') || 'Last updated'}:{' '}
+                      {new Date(template.updatedAt).toLocaleString()}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleApplyTemplate(template.name)}
+                      className="px-3 py-2 text-sm font-medium text-[var(--color-primary)] border border-[var(--color-primary)] rounded-lg hover:bg-[var(--color-primary)]/10 transition-colors"
+                    >
+                      {t('calculator.apply') || 'Apply'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteTemplate(template.name)}
+                      className="px-3 py-2 text-sm font-medium text-rose-600 border border-rose-200 rounded-lg hover:bg-rose-50 dark:border-rose-700 dark:hover:bg-rose-900 transition-colors"
+                    >
+                      {t('calculator.delete') || 'Delete'}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t('calculator.noSavedTemplates') || 'No templates saved yet.'}
+          </p>
+        )}
+      </div>
+
       {/* Calculator Tabs */}
       <div
         className="mb-6"
@@ -350,6 +489,7 @@ export function SplitCalculator() {
         subtotal={calculateSubtotal()}
         currency={state.currency}
         rounding={state.rounding}
+        onExport={handleExport}
       />
     </div>
   );

--- a/frontend/src/components/SplitCalculator/SplitCalculator.tsx
+++ b/frontend/src/components/SplitCalculator/SplitCalculator.tsx
@@ -15,6 +15,7 @@ import {
   saveCalculatorTemplate,
 } from "../../services/calculatorTemplateStore";
 import { exportSplitCalculation } from "../../utils/exportSplitCalculation";
+import { buildCalculatorShareUrl } from "../../utils/calculatorShare";
 
 export type CalculatorType = "equal" | "itemized" | "percentage" | "custom";
 
@@ -66,10 +67,14 @@ const CURRENCIES = [
   { code: "XLM", symbol: "XLM", name: "Stellar Lumens" },
 ];
 
-export function SplitCalculator() {
+interface SplitCalculatorProps {
+  initialState?: CalculatorState;
+}
+
+export function SplitCalculator({ initialState }: SplitCalculatorProps) {
   const { t } = useTranslation();
-  const [activeTab, setActiveTab] = useState<CalculatorType>("equal");
-  const [state, setState] = useState<CalculatorState>(INITIAL_STATE);
+  const [activeTab, setActiveTab] = useState<CalculatorType>(initialState?.type ?? "equal");
+  const [state, setState] = useState<CalculatorState>(initialState ?? INITIAL_STATE);
   const [savedTemplates, setSavedTemplates] = useState<CalculatorTemplate[]>([]);
   const [templateName, setTemplateName] = useState('');
   const [templateError, setTemplateError] = useState<string | null>(null);
@@ -82,6 +87,13 @@ export function SplitCalculator() {
   const updateState = useCallback((updates: Partial<CalculatorState>) => {
     setState((prev) => ({ ...prev, ...updates }));
   }, []);
+
+  useEffect(() => {
+    if (initialState) {
+      setState(initialState);
+      setActiveTab(initialState.type);
+    }
+  }, [initialState]);
 
   const calculateSubtotal = () => {
     return state.totalAmount + state.taxAmount + state.tipAmount;
@@ -144,16 +156,7 @@ export function SplitCalculator() {
   };
 
   const handleShare = async () => {
-    const summary = {
-      type: state.type,
-      participants: state.participants,
-      items: state.items,
-      subtotal: calculateSubtotal(),
-      currency: state.currency,
-    };
-
-    const encoded = btoa(JSON.stringify(summary));
-    const shareUrl = `${window.location.origin}/calculator?data=${encoded}`;
+    const shareUrl = `${window.location.origin}${buildCalculatorShareUrl(state)}`;
 
     if (navigator.share) {
       try {

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -72,6 +72,13 @@ const router = createBrowserRouter([
         },
       },
       {
+        path: "/calculator",
+        lazy: async () => {
+          const { default: SplitCalculatorPage } = await import("./pages/SplitCalculatorPage");
+          return { Component: SplitCalculatorPage };
+        },
+      },
+      {
         path: "/notifications",
         lazy: async () => {
           const { default: NotificationCenterPage } = await import("./pages/NotificationCenterPage");

--- a/frontend/src/pages/SplitCalculatorPage.spec.tsx
+++ b/frontend/src/pages/SplitCalculatorPage.spec.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { buildCalculatorShareUrl } from '../utils/calculatorShare';
+import SplitCalculatorPage from './SplitCalculatorPage';
+
+describe('SplitCalculatorPage', () => {
+  it('hydrates calculator state from a valid share link', () => {
+    const shareState = {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 5, percentage: 50, items: [] },
+        { id: '2', name: 'Bob', amount: 5, percentage: 50, items: [] },
+      ],
+      items: [],
+      totalAmount: 10,
+      taxAmount: 1,
+      tipAmount: 2,
+      currency: 'EUR',
+      rounding: 'none',
+    };
+
+    const shareUrl = buildCalculatorShareUrl(shareState);
+
+    render(
+      <MemoryRouter initialEntries={[shareUrl]}>
+        <Routes>
+          <Route path="/calculator" element={<SplitCalculatorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByLabelText(/currency/i)).toHaveValue('EUR');
+  });
+
+  it('renders a fallback message for invalid share payloads', () => {
+    render(
+      <MemoryRouter initialEntries={["/calculator?data=invalid-data"]}>
+        <Routes>
+          <Route path="/calculator" element={<SplitCalculatorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/invalid calculator link/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/SplitCalculatorPage.tsx
+++ b/frontend/src/pages/SplitCalculatorPage.tsx
@@ -1,0 +1,34 @@
+import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { SplitCalculator } from '../components/SplitCalculator/SplitCalculator';
+import { decodeCalculatorShare } from '../utils/calculatorShare';
+
+export default function SplitCalculatorPage() {
+  const { t } = useTranslation();
+  const [searchParams] = useSearchParams();
+  const encodedData = searchParams.get('data') ?? undefined;
+
+  const initialState = useMemo(
+    () => (encodedData ? decodeCalculatorShare(encodedData) : undefined),
+    [encodedData],
+  );
+
+  const invalidShare = encodedData !== undefined && initialState === null;
+  const invalidShareMessage = t('calculator.invalidShareLink');
+  const invalidShareText =
+    invalidShareMessage === 'calculator.invalidShareLink'
+      ? 'Invalid calculator link. Showing default calculator state.'
+      : invalidShareMessage;
+
+  return (
+    <div className="max-w-6xl mx-auto p-6">
+      {invalidShare && (
+        <div className="mb-6 rounded-2xl border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900 dark:border-rose-700 dark:bg-rose-950/20 dark:text-rose-100">
+          {invalidShareText}
+        </div>
+      )}
+      <SplitCalculator initialState={initialState ?? undefined} />
+    </div>
+  );
+}

--- a/frontend/src/services/calculatorTemplateStore.spec.ts
+++ b/frontend/src/services/calculatorTemplateStore.spec.ts
@@ -1,0 +1,122 @@
+import {
+  clearCalculatorTemplates,
+  deleteCalculatorTemplate,
+  DuplicateTemplateNameError,
+  getCalculatorTemplate,
+  listCalculatorTemplates,
+  saveCalculatorTemplate,
+} from './calculatorTemplateStore';
+
+describe('calculatorTemplateStore', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('saves and lists a new calculator template', () => {
+    const template = saveCalculatorTemplate('Lunch Split', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 10, percentage: 50, items: [] },
+        { id: '2', name: 'Bob', amount: 10, percentage: 50, items: [] },
+      ],
+      items: [],
+      totalAmount: 20,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'USD',
+      rounding: 'none',
+    });
+
+    expect(template.name).toBe('Lunch Split');
+    expect(listCalculatorTemplates()).toHaveLength(1);
+    expect(listCalculatorTemplates()[0].name).toBe('Lunch Split');
+  });
+
+  it('rejects duplicate template names', () => {
+    saveCalculatorTemplate('Lunch Split', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 0, percentage: 0, items: [] },
+      ],
+      items: [],
+      totalAmount: 0,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'USD',
+      rounding: 'none',
+    });
+
+    expect(() =>
+      saveCalculatorTemplate('Lunch Split', {
+        type: 'equal',
+        participants: [
+          { id: '1', name: 'Alice', amount: 0, percentage: 0, items: [] },
+        ],
+        items: [],
+        totalAmount: 0,
+        taxAmount: 0,
+        tipAmount: 0,
+        currency: 'USD',
+        rounding: 'none',
+      }),
+    ).toThrow(DuplicateTemplateNameError);
+  });
+
+  it('returns a deep clone when loading a calculator template', () => {
+    saveCalculatorTemplate('Dinner', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 10, percentage: 0, items: [] },
+      ],
+      items: [],
+      totalAmount: 10,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'USD',
+      rounding: 'none',
+    });
+
+    const loadedTemplate = getCalculatorTemplate('Dinner');
+    expect(loadedTemplate).not.toBeNull();
+    if (loadedTemplate) {
+      loadedTemplate.state.totalAmount = 999;
+    }
+
+    const again = getCalculatorTemplate('Dinner');
+    expect(again?.state.totalAmount).toBe(10);
+  });
+
+  it('deletes a template and clears storage', () => {
+    saveCalculatorTemplate('Gym', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 0, percentage: 0, items: [] },
+      ],
+      items: [],
+      totalAmount: 0,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'USD',
+      rounding: 'none',
+    });
+
+    deleteCalculatorTemplate('Gym');
+    expect(listCalculatorTemplates()).toHaveLength(0);
+
+    saveCalculatorTemplate('Office', {
+      type: 'equal',
+      participants: [
+        { id: '1', name: 'Alice', amount: 0, percentage: 0, items: [] },
+      ],
+      items: [],
+      totalAmount: 0,
+      taxAmount: 0,
+      tipAmount: 0,
+      currency: 'USD',
+      rounding: 'none',
+    });
+
+    clearCalculatorTemplates();
+    expect(listCalculatorTemplates()).toHaveLength(0);
+  });
+});

--- a/frontend/src/services/calculatorTemplateStore.ts
+++ b/frontend/src/services/calculatorTemplateStore.ts
@@ -1,0 +1,109 @@
+import type { CalculatorState } from '../components/SplitCalculator/SplitCalculator';
+
+const STORAGE_KEY = 'splitcalculator_templates_v1';
+
+export interface CalculatorTemplate {
+  name: string;
+  state: CalculatorState;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class DuplicateTemplateNameError extends Error {
+  constructor(name: string) {
+    super(`A template named '${name}' already exists.`);
+    this.name = 'DuplicateTemplateNameError';
+  }
+}
+
+export class CalculatorTemplateStoreError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CalculatorTemplateStoreError';
+  }
+}
+
+function safelyParseTemplates(raw: string | null): Record<string, CalculatorTemplate> {
+  if (!raw) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return {};
+    }
+
+    return Object.entries(parsed).reduce((acc, [key, value]) => {
+      if (
+        typeof key === 'string' &&
+        typeof value === 'object' &&
+        value !== null &&
+        typeof (value as any).name === 'string' &&
+        typeof (value as any).createdAt === 'string' &&
+        typeof (value as any).updatedAt === 'string' &&
+        typeof (value as any).state === 'object'
+      ) {
+        acc[key] = value as CalculatorTemplate;
+      }
+      return acc;
+    }, {} as Record<string, CalculatorTemplate>);
+  } catch {
+    return {};
+  }
+}
+
+function persistTemplates(templates: Record<string, CalculatorTemplate>) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(templates));
+}
+
+function cloneState(state: CalculatorState): CalculatorState {
+  return JSON.parse(JSON.stringify(state));
+}
+
+export function listCalculatorTemplates(): CalculatorTemplate[] {
+  const storage = safelyParseTemplates(localStorage.getItem(STORAGE_KEY));
+  return Object.values(storage);
+}
+
+export function getCalculatorTemplate(name: string): CalculatorTemplate | null {
+  const storage = safelyParseTemplates(localStorage.getItem(STORAGE_KEY));
+  const candidate = storage[name];
+  return candidate ? { ...candidate, state: cloneState(candidate.state) } : null;
+}
+
+export function saveCalculatorTemplate(name: string, state: CalculatorState): CalculatorTemplate {
+  const normalizedName = name.trim();
+  if (!normalizedName) {
+    throw new CalculatorTemplateStoreError('Template name cannot be empty.');
+  }
+
+  const storage = safelyParseTemplates(localStorage.getItem(STORAGE_KEY));
+  if (storage[normalizedName]) {
+    throw new DuplicateTemplateNameError(normalizedName);
+  }
+
+  const template: CalculatorTemplate = {
+    name: normalizedName,
+    state: cloneState(state),
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  storage[normalizedName] = template;
+  persistTemplates(storage);
+
+  return template;
+}
+
+export function deleteCalculatorTemplate(name: string): void {
+  const storage = safelyParseTemplates(localStorage.getItem(STORAGE_KEY));
+  if (storage[name]) {
+    delete storage[name];
+    persistTemplates(storage);
+  }
+}
+
+export function clearCalculatorTemplates(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/frontend/src/utils/calculatorShare.spec.ts
+++ b/frontend/src/utils/calculatorShare.spec.ts
@@ -1,0 +1,36 @@
+import { buildCalculatorShareUrl, decodeCalculatorShare, encodeCalculatorShare } from './calculatorShare';
+import type { CalculatorState } from '../components/SplitCalculator/SplitCalculator';
+
+describe('calculatorShare', () => {
+  const sampleState: CalculatorState = {
+    type: 'equal',
+    participants: [
+      { id: '1', name: 'Alice', amount: 10, percentage: 50, items: [] },
+      { id: '2', name: 'Bob', amount: 10, percentage: 50, items: [] },
+    ],
+    items: [],
+    totalAmount: 20,
+    taxAmount: 2,
+    tipAmount: 3,
+    currency: 'USD',
+    rounding: 'none',
+  };
+
+  it('encodes and decodes calculator state correctly', () => {
+    const raw = encodeCalculatorShare(sampleState);
+    const decoded = decodeCalculatorShare(raw);
+
+    expect(decoded).toEqual(sampleState);
+  });
+
+  it('builds a calculator share link containing the calculator route', () => {
+    const link = buildCalculatorShareUrl(sampleState);
+
+    expect(link).toContain('/calculator?data=');
+    expect(link).not.toContain(' ');
+  });
+
+  it('returns null for invalid share payloads', () => {
+    expect(decodeCalculatorShare('not-base64')).toBeNull();
+  });
+});

--- a/frontend/src/utils/calculatorShare.ts
+++ b/frontend/src/utils/calculatorShare.ts
@@ -1,0 +1,119 @@
+import type { CalculatorState, CalculatorType, Participant, SplitItem } from '../components/SplitCalculator/SplitCalculator';
+
+const SHARE_VERSION = 1;
+
+export interface CalculatorSharePayload {
+  version: number;
+  state: CalculatorState;
+}
+
+export interface LegacyCalculatorSharePayload {
+  type: CalculatorType;
+  participants: Participant[];
+  items: SplitItem[];
+  subtotal: number;
+  currency: string;
+  rounding?: CalculatorState['rounding'];
+}
+
+function base64Encode(value: string): string {
+  const bytes = new TextEncoder().encode(value);
+  let binary = '';
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function base64Decode(value: string): string {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function isCalculatorState(value: unknown): value is CalculatorState {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const candidate = value as CalculatorState;
+  return (
+    candidate != null &&
+    typeof candidate.type === 'string' &&
+    Array.isArray(candidate.participants) &&
+    Array.isArray(candidate.items) &&
+    typeof candidate.totalAmount === 'number' &&
+    typeof candidate.taxAmount === 'number' &&
+    typeof candidate.tipAmount === 'number' &&
+    typeof candidate.currency === 'string' &&
+    ['none', 'up', 'down', 'nearest'].includes(candidate.rounding)
+  );
+}
+
+export function encodeCalculatorShare(state: CalculatorState): string {
+  const payload: CalculatorSharePayload = {
+    version: SHARE_VERSION,
+    state,
+  };
+
+  return base64Encode(JSON.stringify(payload));
+}
+
+function parseLegacyPayload(value: unknown): CalculatorState | null {
+  if (typeof value !== 'object' || value === null) {
+    return null;
+  }
+
+  const legacy = value as LegacyCalculatorSharePayload;
+  if (
+    typeof legacy.type !== 'string' ||
+    !Array.isArray(legacy.participants) ||
+    !Array.isArray(legacy.items) ||
+    typeof legacy.subtotal !== 'number' ||
+    typeof legacy.currency !== 'string'
+  ) {
+    return null;
+  }
+
+  return {
+    type: legacy.type,
+    participants: legacy.participants,
+    items: legacy.items,
+    totalAmount: legacy.subtotal,
+    taxAmount: 0,
+    tipAmount: 0,
+    currency: legacy.currency,
+    rounding: legacy.rounding ?? 'none',
+  };
+}
+
+export function decodeCalculatorShare(encoded: string): CalculatorState | null {
+  try {
+    const raw = decodeURIComponent(encoded);
+    const json = base64Decode(raw);
+    const parsed = JSON.parse(json) as unknown;
+
+    if (typeof parsed === 'object' && parsed !== null && 'version' in parsed) {
+      const payload = parsed as CalculatorSharePayload;
+      if (payload.version !== SHARE_VERSION) {
+        return null;
+      }
+
+      if (isCalculatorState(payload.state)) {
+        return payload.state;
+      }
+
+      return null;
+    }
+
+    return parseLegacyPayload(parsed);
+  } catch {
+    return null;
+  }
+}
+
+export function buildCalculatorShareUrl(state: CalculatorState): string {
+  const encoded = encodeURIComponent(encodeCalculatorShare(state));
+  return `/calculator?data=${encoded}`;
+}

--- a/frontend/src/utils/calculatorShare.ts
+++ b/frontend/src/utils/calculatorShare.ts
@@ -36,7 +36,6 @@ function base64Decode(value: string): string {
 
 function isCalculatorState(value: unknown): value is CalculatorState {
   if (typeof value !== 'object' || value === null) return false;
-
   const candidate = value as CalculatorState;
   return (
     candidate != null &&
@@ -56,7 +55,6 @@ export function encodeCalculatorShare(state: CalculatorState): string {
     version: SHARE_VERSION,
     state,
   };
-
   return base64Encode(JSON.stringify(payload));
 }
 

--- a/frontend/src/utils/exportSplitCalculation.spec.ts
+++ b/frontend/src/utils/exportSplitCalculation.spec.ts
@@ -1,0 +1,54 @@
+import { exportSplitCalculation, buildSplitCalculationFileName } from './exportSplitCalculation';
+
+describe('exportSplitCalculation', () => {
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  const clickSpy = vi.fn();
+  const elementMock = {
+    href: '',
+    download: '',
+    click: clickSpy,
+  } as unknown as HTMLAnchorElement;
+
+  beforeEach(() => {
+    vi.spyOn(document, 'createElement').mockImplementation(() => elementMock);
+    vi.spyOn(URL, 'createObjectURL').mockReturnValue('blob://test-url');
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    clickSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(URL, 'createObjectURL', {
+      value: originalCreateObjectURL,
+      writable: true,
+    });
+    Object.defineProperty(URL, 'revokeObjectURL', {
+      value: originalRevokeObjectURL,
+      writable: true,
+    });
+  });
+
+  it('creates a JSON export and triggers a download', () => {
+    exportSplitCalculation(
+      {
+        type: 'equal',
+        participants: [{ id: '1', name: 'Alice', amount: 10 }],
+        items: [],
+        subtotal: 10,
+        currency: 'USD',
+      },
+      'custom-name.json',
+    );
+
+    expect(elementMock.href).toBe('blob://test-url');
+    expect(elementMock.download).toBe('custom-name.json');
+    expect(clickSpy).toHaveBeenCalled();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob://test-url');
+  });
+
+  it('generates a default file name when none is provided', () => {
+    const fileName = buildSplitCalculationFileName('test-prefix');
+    expect(fileName).toMatch(/^test-prefix-\d+\.json$/);
+  });
+});

--- a/frontend/src/utils/exportSplitCalculation.ts
+++ b/frontend/src/utils/exportSplitCalculation.ts
@@ -1,0 +1,28 @@
+export interface ExportSplitCalculationPayload {
+  type: string;
+  participants: Array<Record<string, unknown>>;
+  items: Array<Record<string, unknown>>;
+  subtotal: number;
+  currency: string;
+  rounding?: string;
+}
+
+export function buildSplitCalculationFileName(prefix = 'split-calculation'): string {
+  return `${prefix}-${Date.now()}.json`;
+}
+
+export function exportSplitCalculation(
+  payload: ExportSplitCalculationPayload,
+  fileName = buildSplitCalculationFileName(),
+): void {
+  const file = new Blob([JSON.stringify(payload, null, 2)], {
+    type: 'application/json',
+  });
+  const url = URL.createObjectURL(file);
+  const anchor = document.createElement('a');
+
+  anchor.href = url;
+  anchor.download = fileName;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Closes #493 

## Summary

This PR adds route-level support for shared Split Calculator links in the StellarSplit frontend. It introduces a dedicated `/calculator` page and a shared-state parser so exported calculator links can round-trip through the router and restore state when valid payloads are present.

## Related issue

- #493 Split Calculator Deep-Link Route Support

## Problem

- `frontend/src/components/SplitCalculator/SplitCalculator.tsx` currently exports share links under `/calculator?data=...`
- The React router did not mount a real `/calculator` route
- There was no hydration path for shared calculator state on page reload or incoming links

## What changed

### Added
- `frontend/src/pages/SplitCalculatorPage.tsx`
  - New routed calculator page
  - Reads `data` from URL search parameters
  - Decodes shared calculator payloads
  - Displays fallback messaging for invalid or malformed payloads
  - Passes hydrated state into `SplitCalculator`

- `frontend/src/utils/calculatorShare.ts`
  - Isolated shared-state encoding and decoding logic
  - Builds URL-safe share links
  - Handles invalid payloads gracefully

### Updated
- `frontend/src/main.tsx`
  - Added a real `/calculator` route for the routed calculator page

- `frontend/src/components/SplitCalculator/SplitCalculator.tsx`
  - Added support for `initialState`
  - Uses shared-state URL builder/decoder flow

## Validation

- Added tests in `frontend/src/utils/calculatorShare.spec.ts`
- Added tests in `frontend/src/pages/SplitCalculatorPage.spec.tsx`
- Verified:
  - valid share links hydrate calculator state
  - invalid payloads render fallback messaging
  - route hydration works after reload

## Acceptance criteria

- Shared calculator links resolve to a real `/calculator` route
- Valid `?data=...` payloads restore calculator state
- Invalid or malformed payloads fall back to default state with a warning
