### PR TITLE
Fix: Test Webhook Isolation

### DIFF
--- a/backend/src/webhooks/test-webhook-dispatcher.ts
+++ b/backend/src/webhooks/test-webhook-dispatcher.ts
@@ -1,0 +1,25 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { WebhookDeliveryService } from './webhook-delivery.service';
+import { Webhook } from './webhook.entity';
+import { WebhookEventType } from './webhook.entity';
+
+@Injectable()
+export class TestWebhookDispatcher {
+  private readonly logger = new Logger(TestWebhookDispatcher.name);
+
+  constructor(private readonly deliveryService: WebhookDeliveryService) {}
+
+  /**
+   * Dispatches a test payload to a single specific webhook, bypassing the bulk event fan-out.
+   */
+  async dispatchTest(
+    webhook: Webhook,
+    eventType: WebhookEventType,
+    payload: Record<string, any>,
+  ): Promise<void> {
+    this.logger.log(`Dispatching test event ${eventType} to webhook ${webhook.id}`);
+    
+    // Call a direct delivery method on deliveryService instead of triggerEvent
+    await this.deliveryService.triggerSingleWebhook(webhook, eventType, payload);
+  }
+}

--- a/backend/src/webhooks/webhook-delivery.service.spec.ts
+++ b/backend/src/webhooks/webhook-delivery.service.spec.ts
@@ -106,6 +106,43 @@ describe('WebhookDeliveryService', () => {
     });
   });
 
+  describe('triggerSingleWebhook', () => {
+    it('should queue delivery for a single webhook without querying database', async () => {
+      const webhook: any = {
+        id: 'webhook-single',
+        userId: 'user-1',
+        url: 'https://example.com/test',
+        events: [WebhookEventType.SPLIT_CREATED],
+        secret: 'test-secret',
+        isActive: true,
+      };
+
+      mockDeliveryRepository.create.mockReturnValue({
+        id: 'delivery-test',
+        webhookId: 'webhook-single',
+        eventType: WebhookEventType.SPLIT_CREATED,
+        payload: { test: 'payload' },
+        status: DeliveryStatus.PENDING,
+      });
+      mockDeliveryRepository.save.mockResolvedValue({
+        id: 'delivery-test',
+      });
+      mockQueue.add.mockResolvedValue({});
+
+      await service.triggerSingleWebhook(
+        webhook,
+        WebhookEventType.SPLIT_CREATED,
+        { test: 'payload' },
+      );
+
+      expect(mockWebhookRepository.createQueryBuilder).not.toHaveBeenCalled();
+      expect(mockDeliveryRepository.create).toHaveBeenCalledWith(expect.objectContaining({
+        webhookId: 'webhook-single',
+      }));
+      expect(mockQueue.add).toHaveBeenCalled();
+    });
+  });
+
   describe('getDeliveryLogs', () => {
     it('should return delivery logs for a webhook', async () => {
       const deliveries = [

--- a/backend/src/webhooks/webhook-delivery.service.ts
+++ b/backend/src/webhooks/webhook-delivery.service.ts
@@ -66,6 +66,18 @@ export class WebhookDeliveryService {
   }
 
   /**
+   * Trigger delivery to a single specific webhook
+   */
+  async triggerSingleWebhook(
+    webhook: Webhook,
+    eventType: WebhookEventType,
+    payload: Record<string, any>,
+  ): Promise<void> {
+    this.logger.log(`Triggering isolated ${eventType} event for webhook ${webhook.id}`);
+    await this.queueDelivery(webhook, eventType, payload);
+  }
+
+  /**
    * Queue a webhook delivery job
    */
   private async queueDelivery(

--- a/backend/src/webhooks/webhooks.controller.spec.ts
+++ b/backend/src/webhooks/webhooks.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
 import { WebhookDeliveryService } from './webhook-delivery.service';
+import { TestWebhookDispatcher } from './test-webhook-dispatcher';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 import { UpdateWebhookDto } from './dto/update-webhook.dto';
 import { TestWebhookDto } from './dto/test-webhook.dto';
@@ -11,6 +12,7 @@ describe('WebhooksController', () => {
   let controller: WebhooksController;
   let webhooksService: WebhooksService;
   let deliveryService: WebhookDeliveryService;
+  let testDispatcher: TestWebhookDispatcher;
 
   const mockWebhooksService = {
     create: jest.fn(),
@@ -21,9 +23,12 @@ describe('WebhooksController', () => {
   };
 
   const mockDeliveryService = {
-    triggerEvent: jest.fn(),
     getDeliveryLogs: jest.fn(),
     getDeliveryStats: jest.fn(),
+  };
+
+  const mockTestDispatcher = {
+    dispatchTest: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -38,6 +43,10 @@ describe('WebhooksController', () => {
           provide: WebhookDeliveryService,
           useValue: mockDeliveryService,
         },
+        {
+          provide: TestWebhookDispatcher,
+          useValue: mockTestDispatcher,
+        },
       ],
     }).compile();
 
@@ -46,6 +55,7 @@ describe('WebhooksController', () => {
     deliveryService = module.get<WebhookDeliveryService>(
       WebhookDeliveryService,
     );
+    testDispatcher = module.get<TestWebhookDispatcher>(TestWebhookDispatcher);
   });
 
   afterEach(() => {
@@ -152,12 +162,16 @@ describe('WebhooksController', () => {
       };
 
       mockWebhooksService.findOne.mockResolvedValue(webhook);
-      mockDeliveryService.triggerEvent.mockResolvedValue(undefined);
+      mockTestDispatcher.dispatchTest.mockResolvedValue(undefined);
 
       const result = await controller.testWebhook('webhook-123', testDto);
 
       expect(mockWebhooksService.findOne).toHaveBeenCalledWith('webhook-123');
-      expect(mockDeliveryService.triggerEvent).toHaveBeenCalled();
+      expect(mockTestDispatcher.dispatchTest).toHaveBeenCalledWith(
+        webhook,
+        testDto.eventType,
+        testDto.payload,
+      );
       expect(result.message).toBe('Test webhook triggered');
     });
   });

--- a/backend/src/webhooks/webhooks.controller.ts
+++ b/backend/src/webhooks/webhooks.controller.ts
@@ -20,6 +20,7 @@ import {
 } from '@nestjs/swagger';
 import { WebhooksService } from './webhooks.service';
 import { WebhookDeliveryService } from './webhook-delivery.service';
+import { TestWebhookDispatcher } from './test-webhook-dispatcher';
 import { CreateWebhookDto } from './dto/create-webhook.dto';
 import { UpdateWebhookDto } from './dto/update-webhook.dto';
 import { TestWebhookDto } from './dto/test-webhook.dto';
@@ -32,6 +33,7 @@ export class WebhooksController {
   constructor(
     private readonly webhooksService: WebhooksService,
     private readonly deliveryService: WebhookDeliveryService,
+    private readonly testDispatcher: TestWebhookDispatcher,
   ) {}
 
   @Post()
@@ -117,17 +119,17 @@ export class WebhooksController {
   ) {
     const webhook = await this.webhooksService.findOne(id);
 
-    // Use the delivery service to trigger a test event
+    // Use the direct dispatcher to send only to this webhook
     const payload = testDto.payload || {
       test: true,
       message: 'This is a test webhook',
       timestamp: new Date().toISOString(),
     };
 
-    await this.deliveryService.triggerEvent(
+    await this.testDispatcher.dispatchTest(
+      webhook,
       testDto.eventType,
       payload,
-      webhook.userId,
     );
 
     return {

--- a/backend/src/webhooks/webhooks.module.ts
+++ b/backend/src/webhooks/webhooks.module.ts
@@ -4,6 +4,7 @@ import { BullModule } from '@nestjs/bull';
 import { WebhooksController } from './webhooks.controller';
 import { WebhooksService } from './webhooks.service';
 import { WebhookDeliveryService } from './webhook-delivery.service';
+import { TestWebhookDispatcher } from './test-webhook-dispatcher';
 import { WebhookProcessor } from './webhook.processor';
 import { Webhook } from './webhook.entity';
 import { WebhookDelivery } from './webhook-delivery.entity';
@@ -25,7 +26,7 @@ import { WebhookDelivery } from './webhook-delivery.entity';
     }),
   ],
   controllers: [WebhooksController],
-  providers: [WebhooksService, WebhookDeliveryService, WebhookProcessor],
-  exports: [WebhooksService, WebhookDeliveryService],
+  providers: [WebhooksService, WebhookDeliveryService, WebhookProcessor, TestWebhookDispatcher],
+  exports: [WebhooksService, WebhookDeliveryService, TestWebhookDispatcher],
 })
 export class WebhooksModule {}


### PR DESCRIPTION
Fixes #475. 
- Created TestWebhookDispatcher to handle single-webhook delivery.
- Added triggerSingleWebhook to WebhookDeliveryService to bypass bulk fan-out.
- Updated WebhooksController to use TestWebhookDispatcher for the test endpoint.
- Adjusted tests to reflect the new architecture.