### PR TITLE
feat: localize collaboration activity messages

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -140,6 +140,15 @@
             "viewReports": "Berichte anzeigen"
         }
     },
+    "activityFeed": {
+        "someone": "Jemand",
+        "splitCreated": "hat {{title}} erstellt",
+        "paymentMade": "hat {{amount}} für {{title}} gezahlt",
+        "paymentReceived": "hat eine Zahlung für {{title}} erhalten",
+        "splitCompleted": "hat {{title}} als abgeschlossen markiert",
+        "splitEdited": "hat {{title}} aktualisiert",
+        "generic": "hat ein Update zu {{title}} hinzugefügt"
+    },
     "languages": {
         "en": "Englisch",
         "es": "Spanisch",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -236,6 +236,15 @@
             "itemPriceRequired": "All items must have a price greater than zero."
         }
     },
+    "activityFeed": {
+        "someone": "Someone",
+        "splitCreated": "created {{title}}",
+        "paymentMade": "paid {{amount}} toward {{title}}",
+        "paymentReceived": "received a payment for {{title}}",
+        "splitCompleted": "marked {{title}} as completed",
+        "splitEdited": "updated {{title}}",
+        "generic": "added an update to {{title}}"
+    },
     "languages": {
         "en": "English",
         "es": "Spanish",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -140,6 +140,15 @@
             "viewReports": "Ver informes"
         }
     },
+    "activityFeed": {
+        "someone": "Alguien",
+        "splitCreated": "creó {{title}}",
+        "paymentMade": "pagó {{amount}} por {{title}}",
+        "paymentReceived": "recibió un pago por {{title}}",
+        "splitCompleted": "marcó {{title}} como completado",
+        "splitEdited": "actualizó {{title}}",
+        "generic": "añadió una actualización a {{title}}"
+    },
     "languages": {
         "en": "Inglés",
         "es": "Español",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -140,6 +140,15 @@
             "viewReports": "Voir les rapports"
         }
     },
+    "activityFeed": {
+        "someone": "Quelqu'un",
+        "splitCreated": "a créé {{title}}",
+        "paymentMade": "a payé {{amount}} pour {{title}}",
+        "paymentReceived": "a reçu un paiement pour {{title}}",
+        "splitCompleted": "a marqué {{title}} comme terminé",
+        "splitEdited": "a mis à jour {{title}}",
+        "generic": "a ajouté une mise à jour à {{title}}"
+    },
     "languages": {
         "en": "Anglais",
         "es": "Espagnol",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -140,6 +140,15 @@
             "viewReports": "レポートを見る"
         }
     },
+    "activityFeed": {
+        "someone": "誰か",
+        "splitCreated": "が{{title}}を作成",
+        "paymentMade": "が{{title}}に{{amount}}支払い",
+        "paymentReceived": "が{{title}}の支払いを受け取り",
+        "splitCompleted": "が{{title}}を完了としてマーク",
+        "splitEdited": "が{{title}}を更新",
+        "generic": "が{{title}}に更新を追加"
+    },
     "languages": {
         "en": "英語",
         "es": "スペイン語",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -140,6 +140,15 @@
             "viewReports": "Ver relatórios"
         }
     },
+    "activityFeed": {
+        "someone": "Alguém",
+        "splitCreated": "criou {{title}}",
+        "paymentMade": "pagou {{amount}} por {{title}}",
+        "paymentReceived": "recebeu um pagamento por {{title}}",
+        "splitCompleted": "marcou {{title}} como concluído",
+        "splitEdited": "atualizou {{title}}",
+        "generic": "adicionou uma atualização a {{title}}"
+    },
     "languages": {
         "en": "Inglês",
         "es": "Espanhol",

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -140,6 +140,15 @@
             "viewReports": "查看报表"
         }
     },
+    "activityFeed": {
+        "someone": "某人",
+        "splitCreated": "创建了 {{title}}",
+        "paymentMade": "向 {{title}} 支付了 {{amount}}",
+        "paymentReceived": "收到了关于 {{title}} 的付款",
+        "splitCompleted": "将 {{title}} 标记为已完成",
+        "splitEdited": "更新了 {{title}}",
+        "generic": "向 {{title}} 添加了更新"
+    },
     "languages": {
         "en": "英语",
         "es": "西班牙语",

--- a/frontend/src/pages/SplitView/SplitDetailPage.tsx
+++ b/frontend/src/pages/SplitView/SplitDetailPage.tsx
@@ -72,6 +72,7 @@ export const SplitDetailPage = () => {
         try {
             const viewModel = await splitDetailRepository.getSplitDetail(splitId, {
                 currentUserId: activeUserId,
+                t,
             });
 
             setSplit(viewModel.split);

--- a/frontend/src/services/splitDetailRepository.ts
+++ b/frontend/src/services/splitDetailRepository.ts
@@ -1,5 +1,6 @@
 import type { Participant, Split } from '../types';
 import type { ActivityFeedItem } from '../components/Collaboration';
+import type { TFunction } from 'i18next';
 import {
     fetchProfile,
     fetchReceiptSignedUrl,
@@ -12,6 +13,7 @@ import {
     type ApiSplitParticipant,
 } from '../utils/api-client';
 import { getStoredSplitParticipantDirectory } from '../utils/session';
+import { formatActivityMessage } from '../utils/activityMessageFormatter';
 
 export interface SplitDetailViewModel {
     split: Split;
@@ -20,6 +22,7 @@ export interface SplitDetailViewModel {
 
 export interface SplitDetailRepositoryOptions {
     currentUserId: string | null;
+    t?: TFunction;
 }
 
 class SplitDetailRepository {
@@ -67,74 +70,85 @@ class SplitDetailRepository {
     private buildActivityMessage(
         activity: ApiActivityRecord,
         splitTitle: string,
+        t?: TFunction,
     ): ActivityFeedItem {
-        const metadataTitle =
-            typeof activity.metadata.title === 'string' ? activity.metadata.title : splitTitle;
-        const amount =
-            typeof activity.metadata.amount === 'number' || typeof activity.metadata.amount === 'string'
-                ? normalizeDecimal(activity.metadata.amount as number | string)
-                : 0;
-        const actor =
-            typeof activity.metadata.actorName === 'string'
-                ? activity.metadata.actorName
-                : 'Someone';
+        if (!t) {
+            // Fallback to old behavior if t is not provided
+            const metadataTitle =
+                typeof activity.metadata.title === 'string' ? activity.metadata.title : splitTitle;
+            const amount =
+                typeof activity.metadata.amount === 'number' || typeof activity.metadata.amount === 'string'
+                    ? normalizeDecimal(activity.metadata.amount as number | string)
+                    : 0;
+            const actor =
+                typeof activity.metadata.actorName === 'string'
+                    ? activity.metadata.actorName
+                    : 'Someone';
 
-        switch (activity.activityType) {
-            case 'split_created':
-                return {
-                    id: activity.id,
-                    type: 'custom',
-                    userName: actor,
-                    message: `created ${metadataTitle}`,
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
-            case 'payment_made':
-                return {
-                    id: activity.id,
-                    type: 'payment-status',
-                    userName: actor,
-                    message: `paid ${amount > 0 ? amount.toFixed(2) : ''} toward ${metadataTitle}`.trim(),
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
-            case 'payment_received':
-                return {
-                    id: activity.id,
-                    type: 'payment-status',
-                    userName: actor,
-                    message: `received a payment for ${metadataTitle}`,
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
-            case 'split_completed':
-                return {
-                    id: activity.id,
-                    type: 'payment-status',
-                    userName: actor,
-                    message: `marked ${metadataTitle} as completed`,
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
-            case 'split_edited':
-                return {
-                    id: activity.id,
-                    type: 'item-updated',
-                    userName: actor,
-                    message: `updated ${metadataTitle}`,
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
-            default:
-                return {
-                    id: activity.id,
-                    type: 'custom',
-                    userName: actor,
-                    message: `added an update to ${metadataTitle}`,
-                    timestamp: activity.createdAt,
-                    splitId: activity.splitId,
-                };
+            switch (activity.activityType) {
+                case 'split_created':
+                    return {
+                        id: activity.id,
+                        type: 'custom',
+                        userName: actor,
+                        message: `created ${metadataTitle}`,
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+                case 'payment_made':
+                    return {
+                        id: activity.id,
+                        type: 'payment-status',
+                        userName: actor,
+                        message: `paid ${amount > 0 ? amount.toFixed(2) : ''} toward ${metadataTitle}`.trim(),
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+                case 'payment_received':
+                    return {
+                        id: activity.id,
+                        type: 'payment-status',
+                        userName: actor,
+                        message: `received a payment for ${metadataTitle}`,
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+                case 'split_completed':
+                    return {
+                        id: activity.id,
+                        type: 'payment-status',
+                        userName: actor,
+                        message: `marked ${metadataTitle} as completed`,
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+                case 'split_edited':
+                    return {
+                        id: activity.id,
+                        type: 'item-updated',
+                        userName: actor,
+                        message: `updated ${metadataTitle}`,
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+                default:
+                    return {
+                        id: activity.id,
+                        type: 'custom',
+                        userName: actor,
+                        message: `added an update to ${metadataTitle}`,
+                        timestamp: activity.createdAt,
+                        splitId: activity.splitId,
+                    };
+            }
         }
+
+        // Use the formatter when t is provided
+        return formatActivityMessage({
+            t,
+            activity,
+            splitTitle,
+        });
     }
 
     private roundCurrency(value: number): number {
@@ -257,7 +271,7 @@ class SplitDetailRepository {
         };
 
         const activityItems = (activities ?? []).map((activity) =>
-            this.buildActivityMessage(activity, split.title),
+            this.buildActivityMessage(activity, split.title, options.t),
         );
 
         return {

--- a/frontend/src/utils/activityMessageFormatter.test.ts
+++ b/frontend/src/utils/activityMessageFormatter.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatActivityMessage } from './activityMessageFormatter';
+import type { ApiActivityRecord } from './api-client';
+
+describe('formatActivityMessage', () => {
+    const mockSplitTitle = 'Dinner at Nobu';
+    const mockT = vi.fn((key: string, params?: Record<string, string | number>) => {
+        const translations: Record<string, string> = {
+            'activityFeed.someone': 'Someone',
+            'activityFeed.splitCreated': 'created {{title}}',
+            'activityFeed.paymentMade': 'paid {{amount}} toward {{title}}',
+            'activityFeed.paymentReceived': 'received a payment for {{title}}',
+            'activityFeed.splitCompleted': 'marked {{title}} as completed',
+            'activityFeed.splitEdited': 'updated {{title}}',
+            'activityFeed.generic': 'added an update to {{title}}',
+        };
+
+        let result = translations[key] || key;
+        if (params) {
+            Object.entries(params).forEach(([paramKey, value]) => {
+                result = result.replace(`{{${paramKey}}}`, String(value));
+            });
+        }
+        return result;
+    });
+
+    const createMockActivity = (
+        activityType: string,
+        metadata: Record<string, unknown> = {},
+    ): ApiActivityRecord => ({
+        id: 'activity-1',
+        userId: 'user-123',
+        activityType,
+        splitId: 'split-123',
+        metadata: {
+            actorName: 'John Doe',
+            title: mockSplitTitle,
+            ...metadata,
+        },
+        isRead: false,
+        createdAt: '2026-01-01T00:00:00.000Z',
+    });
+
+    describe('English locale (default)', () => {
+        it('formats split_created activity', () => {
+            const activity = createMockActivity('split_created');
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.id).toBe('activity-1');
+            expect(result.type).toBe('custom');
+            expect(result.userName).toBe('John Doe');
+            expect(result.message).toBe('created Dinner at Nobu');
+            expect(result.splitId).toBe('split-123');
+        });
+
+        it('formats payment_made activity with amount', () => {
+            const activity = createMockActivity('payment_made', { amount: 25.50 });
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('payment-status');
+            expect(result.message).toBe('paid 25.50 toward Dinner at Nobu');
+        });
+
+        it('formats payment_made activity without amount', () => {
+            const activity = createMockActivity('payment_made', { amount: 0 });
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('payment-status');
+            expect(result.message).toBe('paid 0.00 toward Dinner at Nobu');
+        });
+
+        it('formats payment_received activity', () => {
+            const activity = createMockActivity('payment_received');
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('payment-status');
+            expect(result.message).toBe('received a payment for Dinner at Nobu');
+        });
+
+        it('formats split_completed activity', () => {
+            const activity = createMockActivity('split_completed');
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('payment-status');
+            expect(result.message).toBe('marked Dinner at Nobu as completed');
+        });
+
+        it('formats split_edited activity', () => {
+            const activity = createMockActivity('split_edited');
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('item-updated');
+            expect(result.message).toBe('updated Dinner at Nobu');
+        });
+
+        it('formats unknown activity type as generic', () => {
+            const activity = createMockActivity('unknown_type');
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.type).toBe('custom');
+            expect(result.message).toBe('added an update to Dinner at Nobu');
+        });
+
+        it('uses metadata title when available', () => {
+            const customTitle = 'Custom Split Title';
+            const activity = createMockActivity('split_created', { title: customTitle });
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe(`created ${customTitle}`);
+        });
+
+        it('uses split title as fallback when metadata title is missing', () => {
+            const activity = createMockActivity('split_created', { title: null });
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe(`created ${mockSplitTitle}`);
+        });
+
+        it('handles missing actor name with translation fallback', () => {
+            const activity = createMockActivity('split_created', { actorName: null });
+            const result = formatActivityMessage({ t: mockT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.userName).toBe('Someone');
+        });
+    });
+
+    describe('French locale (secondary locale smoke test)', () => {
+        const mockFrenchT = vi.fn((key: string, params?: Record<string, string | number>) => {
+            const translations: Record<string, string> = {
+                'activityFeed.someone': 'Quelqu\'un',
+                'activityFeed.splitCreated': 'a créé {{title}}',
+                'activityFeed.paymentMade': 'a payé {{amount}} pour {{title}}',
+                'activityFeed.paymentReceived': 'a reçu un paiement pour {{title}}',
+                'activityFeed.splitCompleted': 'a marqué {{title}} comme terminé',
+                'activityFeed.splitEdited': 'a mis à jour {{title}}',
+                'activityFeed.generic': 'a ajouté une mise à jour à {{title}}',
+            };
+
+            let result = translations[key] || key;
+            if (params) {
+                Object.entries(params).forEach(([paramKey, value]) => {
+                    result = result.replace(`{{${paramKey}}}`, String(value));
+                });
+            }
+            return result;
+        });
+
+        it('formats split_created activity in French', () => {
+            const activity = createMockActivity('split_created');
+            const result = formatActivityMessage({ t: mockFrenchT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe('a créé Dinner at Nobu');
+        });
+
+        it('formats payment_made activity in French', () => {
+            const activity = createMockActivity('payment_made', { amount: 25.50 });
+            const result = formatActivityMessage({ t: mockFrenchT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe('a payé 25.50 pour Dinner at Nobu');
+        });
+
+        it('formats payment_received activity in French', () => {
+            const activity = createMockActivity('payment_received');
+            const result = formatActivityMessage({ t: mockFrenchT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe('a reçu un paiement pour Dinner at Nobu');
+        });
+
+        it('formats split_completed activity in French', () => {
+            const activity = createMockActivity('split_completed');
+            const result = formatActivityMessage({ t: mockFrenchT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe('a marqué Dinner at Nobu comme terminé');
+        });
+
+        it('formats split_edited activity in French', () => {
+            const activity = createMockActivity('split_edited');
+            const result = formatActivityMessage({ t: mockFrenchT, activity, splitTitle: mockSplitTitle });
+
+            expect(result.message).toBe('a mis à jour Dinner at Nobu');
+        });
+    });
+});

--- a/frontend/src/utils/activityMessageFormatter.ts
+++ b/frontend/src/utils/activityMessageFormatter.ts
@@ -1,0 +1,94 @@
+import type { TFunction } from 'i18next';
+import { normalizeDecimal } from './api-client';
+import type { ApiActivityRecord } from './api-client';
+import type { ActivityFeedItem } from '../components/Collaboration';
+
+export interface ActivityMessageFormatterOptions {
+    t: TFunction;
+    activity: ApiActivityRecord;
+    splitTitle: string;
+}
+
+/**
+ * Formats activity messages using translation keys for localization.
+ * Maps backend activity types to translation keys and interpolation data.
+ */
+export function formatActivityMessage({
+    t,
+    activity,
+    splitTitle,
+}: ActivityMessageFormatterOptions): ActivityFeedItem {
+    const metadataTitle =
+        typeof activity.metadata.title === 'string' ? activity.metadata.title : splitTitle;
+    const amount =
+        typeof activity.metadata.amount === 'number' || typeof activity.metadata.amount === 'string'
+            ? normalizeDecimal(activity.metadata.amount as number | string)
+            : 0;
+    const actor =
+        typeof activity.metadata.actorName === 'string'
+            ? activity.metadata.actorName
+            : t('activityFeed.someone');
+
+    const translationKey = getActivityTranslationKey(activity.activityType);
+    const translationParams = getActivityTranslationParams(
+        activity.activityType,
+        metadataTitle,
+        amount,
+    );
+
+    const message = t(translationKey, translationParams);
+    const activityType = getActivityFeedType(activity.activityType);
+
+    return {
+        id: activity.id,
+        type: activityType,
+        userName: actor,
+        message,
+        timestamp: activity.createdAt,
+        splitId: activity.splitId,
+    };
+}
+
+function getActivityTranslationKey(activityType: string): string {
+    switch (activityType) {
+        case 'split_created':
+            return 'activityFeed.splitCreated';
+        case 'payment_made':
+            return 'activityFeed.paymentMade';
+        case 'payment_received':
+            return 'activityFeed.paymentReceived';
+        case 'split_completed':
+            return 'activityFeed.splitCompleted';
+        case 'split_edited':
+            return 'activityFeed.splitEdited';
+        default:
+            return 'activityFeed.generic';
+    }
+}
+
+function getActivityTranslationParams(
+    activityType: string,
+    metadataTitle: string,
+    amount: number,
+): Record<string, string | number> {
+    const params: Record<string, string | number> = { title: metadataTitle };
+    
+    if (activityType === 'payment_made' && amount > 0) {
+        params.amount = amount.toFixed(2);
+    }
+    
+    return params;
+}
+
+function getActivityFeedType(activityType: string): ActivityFeedItem['type'] {
+    switch (activityType) {
+        case 'payment_made':
+        case 'payment_received':
+        case 'split_completed':
+            return 'payment-status';
+        case 'split_edited':
+            return 'item-updated';
+        default:
+            return 'custom';
+    }
+}


### PR DESCRIPTION
This implementation localizes collaboration activity messages by extracting hardcoded English strings from the split detail repository into translation keys across all supported locales (English, French, German, Spanish, Portuguese, Japanese, and Chinese). A new activityMessageFormatter utility maps backend activity types to translation keys with support for interpolation of dynamic values like titles and amounts, while the repository was refactored to use this formatter when a translation function is provided, maintaining backward compatibility through a fallback to the original hardcoded strings. Comprehensive tests validate the formatter's behaviour across all activity types in both the default English locale and a secondary French locale.
Closes #463 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Activity feed messages now display in multiple languages: English, German, Spanish, French, Japanese, Portuguese, and Chinese.

* **Tests**
  * Added test coverage for activity message localization and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->